### PR TITLE
Add Buds Live to RegisteredDeviceModel selection logic

### DIFF
--- a/Galaxy Buds Client/ui/DeviceSelectPage.xaml.cs
+++ b/Galaxy Buds Client/ui/DeviceSelectPage.xaml.cs
@@ -111,7 +111,7 @@ namespace Galaxy_Buds_Client.ui
             }
 
             Properties.Settings.Default.RegisteredDevice = BytesToMacString(_address?.ToByteArrayBigEndian(), 0);
-            Properties.Settings.Default.RegisteredDeviceModel = _device.DeviceName.Contains("Buds+") ? Model.BudsPlus : Model.Buds;
+            Properties.Settings.Default.RegisteredDeviceModel = _device.DeviceName.Contains("Buds+") ? Model.BudsPlus : _device.DeviceName.Contains("Buds Live") ? Model.BudsLive : Model.Buds;
             Properties.Settings.Default.Save();
             _mainWindow.FinalizeSetup();
         }


### PR DESCRIPTION
Add Buds Live option to the RegisteredDeviceModel selection logic. With this addition, I see no issues on my Buds Live.