### PR TITLE
Shorten Korean translation

### DIFF
--- a/GalaxyBudsClient/i18n/ko.xaml
+++ b/GalaxyBudsClient/i18n/ko.xaml
@@ -237,7 +237,7 @@
     <sys:String x:Key="unsupported_feature_current_fwver">현재 버즈 소프트웨어 버전:</sys:String>
     <sys:String x:Key="unsupported_feature_required_fwver">요구되는 버즈 소프트웨어 버전:</sys:String>
 
-    <sys:String x:Key="unsupported_feature_header">버즈 소프트웨어를 공식 갤럭시 웨어러블 앱을 통해 업데이트해 주세요.</sys:String>
+    <sys:String x:Key="unsupported_feature_header">버즈 펌웨어를 업데이트해 주세요</sys:String>
     <sys:String x:Key="unsupported_feature_current_fwver_null">현재 버즈 소프트웨어 버전: 알 수 없음</sys:String>
     <sys:String x:Key="unsupported_feature_required_fwver_null">요구되는 소프트웨어 버전: 지정되지 않음</sys:String>
 


### PR DESCRIPTION
The current translation overflows the header:
![화면 캡처 2021-02-19 001553](https://user-images.githubusercontent.com/13326074/108378460-5be6db80-7248-11eb-9dd9-2a43b10ffd72.png)

This commit shortens the translation so that it matches the English phrasing and doesn't overflow.