### PR TITLE
Detect the official Galaxy Buds app

### DIFF
--- a/GalaxyBudsClient.sln
+++ b/GalaxyBudsClient.sln
@@ -48,8 +48,8 @@ Global
 		{1DFCF45B-9817-45EF-9BBB-9DACA8F3E4E6}.Release - Windows ARM|Any CPU.Build.0 = Release - Windows ARM|Any CPU
 		{1DFCF45B-9817-45EF-9BBB-9DACA8F3E4E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1DFCF45B-9817-45EF-9BBB-9DACA8F3E4E6}.Release|Any CPU.Build.0 = Release|Any CPU
-		{DD32EA98-F26F-4629-B78F-F9F68C9BDA37}.CodeAnalysis|Any CPU.ActiveCfg = CodeAnalysis|Any CPU
-		{DD32EA98-F26F-4629-B78F-F9F68C9BDA37}.CodeAnalysis|Any CPU.Build.0 = CodeAnalysis|Any CPU
+		{DD32EA98-F26F-4629-B78F-F9F68C9BDA37}.CodeAnalysis|Any CPU.ActiveCfg = Release|Any CPU
+		{DD32EA98-F26F-4629-B78F-F9F68C9BDA37}.CodeAnalysis|Any CPU.Build.0 = Release|Any CPU
 		{DD32EA98-F26F-4629-B78F-F9F68C9BDA37}.Debug (Local server)|Any CPU.ActiveCfg = Debug (Local server)|Any CPU
 		{DD32EA98-F26F-4629-B78F-F9F68C9BDA37}.Debug (Local server)|Any CPU.Build.0 = Debug (Local server)|Any CPU
 		{DD32EA98-F26F-4629-B78F-F9F68C9BDA37}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -88,8 +88,8 @@ Global
 		{73B48D11-E52D-46B2-AA81-FE8A50CA8234}.Release - Windows ARM|Any CPU.Build.0 = Release - Windows ARM|Any CPU
 		{73B48D11-E52D-46B2-AA81-FE8A50CA8234}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{73B48D11-E52D-46B2-AA81-FE8A50CA8234}.Release|Any CPU.Build.0 = Release|Any CPU
-		{1411DDEF-EFBC-4BF1-9292-0E74261A587D}.CodeAnalysis|Any CPU.ActiveCfg = Release|Any CPU
-		{1411DDEF-EFBC-4BF1-9292-0E74261A587D}.CodeAnalysis|Any CPU.Build.0 = Release|Any CPU
+		{1411DDEF-EFBC-4BF1-9292-0E74261A587D}.CodeAnalysis|Any CPU.ActiveCfg = CodeAnalysis|Any CPU
+		{1411DDEF-EFBC-4BF1-9292-0E74261A587D}.CodeAnalysis|Any CPU.Build.0 = CodeAnalysis|Any CPU
 		{1411DDEF-EFBC-4BF1-9292-0E74261A587D}.Debug (Local server)|Any CPU.ActiveCfg = Debug (Local server)|Any CPU
 		{1411DDEF-EFBC-4BF1-9292-0E74261A587D}.Debug (Local server)|Any CPU.Build.0 = Debug (Local server)|Any CPU
 		{1411DDEF-EFBC-4BF1-9292-0E74261A587D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU

--- a/GalaxyBudsClient.sln
+++ b/GalaxyBudsClient.sln
@@ -48,8 +48,8 @@ Global
 		{1DFCF45B-9817-45EF-9BBB-9DACA8F3E4E6}.Release - Windows ARM|Any CPU.Build.0 = Release - Windows ARM|Any CPU
 		{1DFCF45B-9817-45EF-9BBB-9DACA8F3E4E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1DFCF45B-9817-45EF-9BBB-9DACA8F3E4E6}.Release|Any CPU.Build.0 = Release|Any CPU
-		{DD32EA98-F26F-4629-B78F-F9F68C9BDA37}.CodeAnalysis|Any CPU.ActiveCfg = Release|Any CPU
-		{DD32EA98-F26F-4629-B78F-F9F68C9BDA37}.CodeAnalysis|Any CPU.Build.0 = Release|Any CPU
+		{DD32EA98-F26F-4629-B78F-F9F68C9BDA37}.CodeAnalysis|Any CPU.ActiveCfg = CodeAnalysis|Any CPU
+		{DD32EA98-F26F-4629-B78F-F9F68C9BDA37}.CodeAnalysis|Any CPU.Build.0 = CodeAnalysis|Any CPU
 		{DD32EA98-F26F-4629-B78F-F9F68C9BDA37}.Debug (Local server)|Any CPU.ActiveCfg = Debug (Local server)|Any CPU
 		{DD32EA98-F26F-4629-B78F-F9F68C9BDA37}.Debug (Local server)|Any CPU.Build.0 = Debug (Local server)|Any CPU
 		{DD32EA98-F26F-4629-B78F-F9F68C9BDA37}.Debug|Any CPU.ActiveCfg = Debug|Any CPU

--- a/GalaxyBudsClient.sln
+++ b/GalaxyBudsClient.sln
@@ -88,8 +88,8 @@ Global
 		{73B48D11-E52D-46B2-AA81-FE8A50CA8234}.Release - Windows ARM|Any CPU.Build.0 = Release - Windows ARM|Any CPU
 		{73B48D11-E52D-46B2-AA81-FE8A50CA8234}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{73B48D11-E52D-46B2-AA81-FE8A50CA8234}.Release|Any CPU.Build.0 = Release|Any CPU
-		{1411DDEF-EFBC-4BF1-9292-0E74261A587D}.CodeAnalysis|Any CPU.ActiveCfg = CodeAnalysis|Any CPU
-		{1411DDEF-EFBC-4BF1-9292-0E74261A587D}.CodeAnalysis|Any CPU.Build.0 = CodeAnalysis|Any CPU
+		{1411DDEF-EFBC-4BF1-9292-0E74261A587D}.CodeAnalysis|Any CPU.ActiveCfg = Release|Any CPU
+		{1411DDEF-EFBC-4BF1-9292-0E74261A587D}.CodeAnalysis|Any CPU.Build.0 = Release|Any CPU
 		{1411DDEF-EFBC-4BF1-9292-0E74261A587D}.Debug (Local server)|Any CPU.ActiveCfg = Debug (Local server)|Any CPU
 		{1411DDEF-EFBC-4BF1-9292-0E74261A587D}.Debug (Local server)|Any CPU.Build.0 = Debug (Local server)|Any CPU
 		{1411DDEF-EFBC-4BF1-9292-0E74261A587D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU

--- a/GalaxyBudsClient/GalaxyBudsClient.csproj
+++ b/GalaxyBudsClient/GalaxyBudsClient.csproj
@@ -16,6 +16,7 @@
         <IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">true</IsWindows>
         <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
         <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>
+        <ApplicationManifest>app.manifest</ApplicationManifest>
     </PropertyGroup>
     <PropertyGroup Condition="'$(IsWindows)'=='true'">
         <DefineConstants>Windows</DefineConstants>

--- a/GalaxyBudsClient/GalaxyBudsClient.csproj
+++ b/GalaxyBudsClient/GalaxyBudsClient.csproj
@@ -59,10 +59,6 @@
         <EmbeddedResource Remove="bin\**" />
         <None Remove="bin\**" />
     </ItemGroup>
-    
-    <ItemGroup>
-      <None Remove="Interface\Pages\BudsAppDetectedPage.xaml" />
-    </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="Avalonia" Version="0.10.0" />

--- a/GalaxyBudsClient/GalaxyBudsClient.csproj
+++ b/GalaxyBudsClient/GalaxyBudsClient.csproj
@@ -59,6 +59,10 @@
         <EmbeddedResource Remove="bin\**" />
         <None Remove="bin\**" />
     </ItemGroup>
+    
+    <ItemGroup>
+      <None Remove="Interface\Pages\BudsAppDetectedPage.xaml" />
+    </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="Avalonia" Version="0.10.0" />
@@ -85,6 +89,18 @@
         <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
         <PackageReference Include="Tmds.DBus" Version="0.9.1" />
         <PackageReference Include="Trinet.Core.IO.Ntfs" Version="4.1.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <AvaloniaResource Update="Interface\Pages\BudsAppDetectedPage.xaml">
+        <Generator>MSBuild:Compile</Generator>
+      </AvaloniaResource>
+    </ItemGroup>
+
+    <ItemGroup>
+      <Compile Update="Interface\Pages\BudsAppDetectedPage.xaml.cs">
+        <DependentUpon>%(Filename)</DependentUpon>
+      </Compile>
     </ItemGroup>
     
     <Choose>

--- a/GalaxyBudsClient/Interface/Pages/AbstractPage.cs
+++ b/GalaxyBudsClient/Interface/Pages/AbstractPage.cs
@@ -37,6 +37,7 @@ namespace GalaxyBudsClient.Interface.Pages
             UnsupportedFeature,
             UpdateAvailable,
             UpdateProgress,
+            BudsAppDetected,
             Undefined
         }
 

--- a/GalaxyBudsClient/Interface/Pages/BudsAppDetectedPage.xaml
+++ b/GalaxyBudsClient/Interface/Pages/BudsAppDetectedPage.xaml
@@ -1,0 +1,65 @@
+﻿<pages:AbstractPage xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:pages="clr-namespace:GalaxyBudsClient.Interface.Pages"
+             xmlns:elements="clr-namespace:GalaxyBudsClient.Interface.Elements"
+             xmlns:items="clr-namespace:GalaxyBudsClient.Interface.Items"
+             mc:Ignorable="d" d:DesignWidth="500" d:DesignHeight="36"
+             x:Class="GalaxyBudsClient.Interface.Pages.BudsAppDetectedPage"
+             DockPanel.Dock="Top" Margin="10,0">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="20"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="10"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="10"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+		<elements:PageHeader Grid.Row="1" Title="{DynamicResource budsapp_header}" BackPressed="BackButton_OnPointerPressed" />
+        
+        <Border Grid.Row="3" Classes="RoundedBorderListItem">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+                <TextBlock Grid.Row="0" Text="{DynamicResource budsapp_text_p1}"
+                           Foreground="{DynamicResource ForegroundTextDimBrush}"
+                           TextWrapping="Wrap" FontSize="14.2" Margin="20,20,20,0" />
+				<TextBlock Grid.Row="1" Text="{DynamicResource budsapp_text_p2}"
+                           Foreground="{DynamicResource ForegroundTextDimBrush}"
+                           TextWrapping="Wrap" FontSize="14.2" Margin="20,10,20,10" />
+			</Grid>
+        </Border>
+        
+        <Border Grid.Row="7" Classes="RoundedBorderListItem">
+            <Grid ClipToBounds="True">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+				<Border Grid.Column="0" Classes="BorderHoverStyle" PointerPressed="BackButton_OnPointerPressed">
+					<Label Content="{DynamicResource back}"
+                           Height="50" FontSize="18"
+                           Foreground="{DynamicResource ForegroundTextBrush}"
+                           Margin="20,0,20,0"
+                           HorizontalContentAlignment="Center"
+                           VerticalContentAlignment="Center" />
+				</Border>
+				<Border Grid.Column="1" Classes="VerticalSeparator" />
+                <Border Grid.Column="2" CornerRadius="{DynamicResource DefaultCornerRadius}" Classes="BorderHoverStyle"
+                        PointerPressed="Next_OnPointerPressed">
+                    <items:IconListItem Text="{DynamicResource continue_button}"
+                                        Source="{DynamicResource NextButton}" 
+                                        Margin="20,0" FontSize="18"/>
+                </Border>
+            </Grid>
+        </Border>
+    </Grid>
+</pages:AbstractPage>

--- a/GalaxyBudsClient/Interface/Pages/BudsAppDetectedPage.xaml.cs
+++ b/GalaxyBudsClient/Interface/Pages/BudsAppDetectedPage.xaml.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using GalaxyBudsClient.Interface.Items;
+using GalaxyBudsClient.Model.Attributes;
+using GalaxyBudsClient.Model.Constants;
+using GalaxyBudsClient.Utils;
+using GalaxyBudsClient.Utils.DynamicLocalization;
+using Serilog;
+
+namespace GalaxyBudsClient.Interface.Pages
+{
+ 	public class BudsAppDetectedPage : AbstractPage
+	{
+		public override Pages PageType => Pages.BudsAppDetected;
+
+		private ContextMenu? _localeMenu;
+
+		public BudsAppDetectedPage() {   
+			AvaloniaXamlLoader.Load(this);
+		}
+
+		private void Next_OnPointerPressed(object? sender, PointerPressedEventArgs e) {
+			MainWindow.Instance.Pager.SwitchPage(Pages.DeviceSelect);
+		}
+
+		private void BackButton_OnPointerPressed(object? sender, PointerPressedEventArgs e) {
+			MainWindow.Instance.Pager.SwitchPage(Pages.Welcome);
+		}
+	}
+}

--- a/GalaxyBudsClient/Interface/Pages/WelcomePage.xaml.cs
+++ b/GalaxyBudsClient/Interface/Pages/WelcomePage.xaml.cs
@@ -73,10 +73,11 @@ namespace GalaxyBudsClient.Interface.Pages
 				pro.WaitForExit();
 				var result = pro.StandardOutput.ReadToEnd();
 				if (result.Contains("SAMSUNGELECTRONICSCO.LTD.GalaxyBuds")) {
-					Process.Start("notepad");
+					MainWindow.Instance.Pager.SwitchPage(Pages.BudsAppDetected);
+				} else {
+					MainWindow.Instance.Pager.SwitchPage(Pages.DeviceSelect);
 				}
 			}
-			MainWindow.Instance.Pager.SwitchPage(Pages.DeviceSelect);
 		}
 
 		private void DarkMode_OnToggled(object? sender, bool e)

--- a/GalaxyBudsClient/Interface/Pages/WelcomePage.xaml.cs
+++ b/GalaxyBudsClient/Interface/Pages/WelcomePage.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
@@ -58,6 +59,23 @@ namespace GalaxyBudsClient.Interface.Pages
 		
 		private void Next_OnPointerPressed(object? sender, PointerPressedEventArgs e)
 		{
+			// Only search for the Buds app on Windows 10 and above
+			if (Environment.OSVersion.Platform == PlatformID.Win32NT && Environment.OSVersion.Version.Major >= 10) {
+				// Using PowerShell because I couldn't find a native way to get a list of UWP apps
+				ProcessStartInfo si = new ProcessStartInfo {
+					FileName = "powershell",
+					Arguments = "Get-AppxPackage SAMSUNGELECTRONICSCO.LTD.GalaxyBuds",
+					RedirectStandardOutput = true,
+					UseShellExecute = false,
+					CreateNoWindow = true
+				};
+				var pro = Process.Start(si);
+				pro.WaitForExit();
+				var result = pro.StandardOutput.ReadToEnd();
+				if (result.Contains("SAMSUNGELECTRONICSCO.LTD.GalaxyBuds")) {
+					Process.Start("notepad");
+				}
+			}
 			MainWindow.Instance.Pager.SwitchPage(Pages.DeviceSelect);
 		}
 

--- a/GalaxyBudsClient/MainWindow.xaml.cs
+++ b/GalaxyBudsClient/MainWindow.xaml.cs
@@ -139,7 +139,7 @@ namespace GalaxyBudsClient
                 ConnectionLostPage, CustomTouchActionPage, DeviceSelectionPage, new SystemInfoPage(),
                 new WelcomePage(), UnsupportedFeaturePage, UpdatePage, UpdateProgressPage, new SystemCoredumpPage(),
                 new HotkeyPage(), new FirmwareSelectionPage(), new FirmwareTransferPage(), new SpatialTestPage(),
-                new BixbyRemapPage(), new CrowdsourcingSettingsPage());
+                new BixbyRemapPage(), new CrowdsourcingSettingsPage(), new BudsAppDetectedPage());
 
             _titleBar = this.FindControl<CustomTitleBar>("TitleBar");
             _titleBar.PointerPressed += (i, e) => PlatformImpl?.BeginMoveDrag(e);

--- a/GalaxyBudsClient/app.manifest
+++ b/GalaxyBudsClient/app.manifest
@@ -1,0 +1,76 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <!-- UAC Manifest Options
+             If you want to change the Windows User Account Control level replace the 
+             requestedExecutionLevel node with one of the following.
+
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
+        <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
+        <requestedExecutionLevel  level="highestAvailable" uiAccess="false" />
+
+            Specifying requestedExecutionLevel element will disable file and registry virtualization. 
+            Remove this element if your application requires this virtualization for backwards
+            compatibility.
+        -->
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of the Windows versions that this application has been tested on
+           and is designed to work with. Uncomment the appropriate elements
+           and Windows will automatically select the most compatible environment. -->
+
+      <!-- Windows Vista -->
+      <!--<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />-->
+
+      <!-- Windows 7 -->
+      <!--<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />-->
+
+      <!-- Windows 8 -->
+      <!--<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />-->
+
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />
+
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+
+    </application>
+  </compatibility>
+
+  <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
+       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
+       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
+       also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. -->
+  <!--
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    </windowsSettings>
+  </application>
+  -->
+
+  <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
+  <!--
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>
+  -->
+
+</assembly>

--- a/GalaxyBudsClient/i18n/en.xaml
+++ b/GalaxyBudsClient/i18n/en.xaml
@@ -528,4 +528,11 @@
     <sys:String x:Key="window_minimize">Minimize</sys:String>
     <sys:String x:Key="window_close">Close</sys:String>
 
+    <!-- Buds app detected page -->
+    <sys:String x:Key="budsapp_header">Galaxy Buds app found</sys:String>
+    <sys:String x:Key="budsapp_text_p1">Looks like you have the official Galaxy Buds app for Windows 10 installed.</sys:String>
+    <sys:String x:Key="budsapp_text_p2">
+      If it is open and connected, Galaxy Buds Manager might have issues connecting to your earbuds. Likewise, the Galaxy Buds app can't connect to your earbuds when Galaxy Buds Manager is running.
+    </sys:String>
+
 </ResourceDictionary>


### PR DESCRIPTION
I noticed that Galaxy Buds Manager doesn't connect to my buds when the [official Galaxy Buds app for Windows](https://www.microsoft.com/store/productId/9NHTLWTKFZNB) is installed.

I added a warning message for those who use both apps.

It only checks if the Buds app is installed because I can't get a list of running UWP apps.