### PR TITLE
Fix Linux Globalization crash

### DIFF
--- a/GalaxyBudsClient/GalaxyBudsClient.csproj
+++ b/GalaxyBudsClient/GalaxyBudsClient.csproj
@@ -39,6 +39,7 @@
     </PropertyGroup>
     <PropertyGroup Condition="'$(IsLinux)'=='true'">
         <DefineConstants>Linux</DefineConstants>
+        <InvariantGlobalization>true</InvariantGlobalization>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug (Local server)' ">


### PR DESCRIPTION
I changed the Linux config to `InvariantGlobalization = true` because the app crashed on Arch systems and this is a working fix as discussed on #334.

Relevant:
https://learn.microsoft.com/en-us/dotnet/core/runtime-config/globalization