### PR TITLE
Linux performance issue

### DIFF
--- a/GalaxyBudsClient/Interface/Elements/LoadingSpinner.xaml
+++ b/GalaxyBudsClient/Interface/Elements/LoadingSpinner.xaml
@@ -7,7 +7,7 @@
                 <RotateTransform Angle="0.0" />
             </Image.RenderTransform>
             <Image.Styles>
-                <Style Selector="Image">
+                <Style Selector="Image[IsVisible=True]">
                     <Style.Animations>
                         <Animation IterationCount="Infinite"
                                    Duration="0:0:.5"> 

--- a/GalaxyBudsClient/Interface/Elements/LoadingSpinner.xaml.cs
+++ b/GalaxyBudsClient/Interface/Elements/LoadingSpinner.xaml.cs
@@ -1,13 +1,31 @@
-﻿using Avalonia.Controls;
+using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
 namespace GalaxyBudsClient.Interface.Elements
 {
     public class LoadingSpinner : UserControl
     {
+        private readonly Image _spinnerImage;
+
         public LoadingSpinner()
         {
             AvaloniaXamlLoader.Load(this);
+
+            _spinnerImage = this.FindControl<Image>("Spinner");
+
+            PropertyChanged += (o, e) =>
+            {
+                if (e.Property.Name == nameof(IsVisible))
+                {
+                    if (e.NewValue != null)
+                    {
+                        if ((bool)e.NewValue)
+                            _spinnerImage.IsVisible = true;
+                        else
+                            _spinnerImage.IsVisible = false;
+                    }
+                }
+            };
         }
     }
 }


### PR DESCRIPTION
Hello. So, on Linux with Nvidia proprietary drivers (didn't have a chance to test it on an AMD GPU), I had an issue where my CPU core goes to 100% usage. It happens whenever LoadingSpinner's IsVisible property sets to true at least one time. And LoadingSpinner has a spinning animation which causes high CPU core usage. For example, in https://github.com/ThePBone/GalaxyBudsClient/blob/master/GalaxyBudsClient/Interface/Pages/HomePage.xaml.cs, _loadingSpinner IsVisible property sets to true at least one time but the animation of it will keep working even after we set it to false.

My workaround is to just stop the animation whenever we get IsVisible property set to false. It's not the best solution because it would be better to actually fix the animation performance issue, but at least this solution works and it is simple.