### PR TITLE
Fix annoying Linux bluetooth connection bug

### DIFF
--- a/GalaxyBudsClient.Bluetooth.Linux/BluetoothService.cs
+++ b/GalaxyBudsClient.Bluetooth.Linux/BluetoothService.cs
@@ -280,6 +280,9 @@ namespace GalaxyBudsClient.Bluetooth.Linux
 
         private async Task<bool> AttemptBasicConnectionAsync(bool noRetry)
         {
+            if (await _device.GetConnectedAsync())
+                return true;
+
             try
             {
                 await _device?.ConnectAsync()!;


### PR DESCRIPTION
When you try to open up the app after your earbuds are paired and connected, it will throw you this error: "org.bluez.Error.Failed Operation already in progress". This happens because the BluetoothService attempts to connect to an already connected device. I see that in the code you expect BlueZException to be thrown with the error code "AlreadyConnected", but that usually doesn't happen, and instead you get the "Failed" error code with the above-mentioned error message. This is what basically causes the bug. And to fix this issue, we just need to check if the device already connected. It is easily fixable with just two lines of code.

Has anyone encountered this issue before? Because it looks like a common issue