### PR TITLE
fix some macos bugs

### DIFF
--- a/GalaxyBudsClient.Bluetooth.WindowsRT/GalaxyBudsClient.Bluetooth.WindowsRT.csproj
+++ b/GalaxyBudsClient.Bluetooth.WindowsRT/GalaxyBudsClient.Bluetooth.WindowsRT.csproj
@@ -17,6 +17,7 @@
         <RepositoryUrl>https://github.com/ThePBone/GalaxyBudsClient</RepositoryUrl>
         <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <EnableWindowsTargeting>true</EnableWindowsTargeting>
     </PropertyGroup>
 
     <ItemGroup>

--- a/GalaxyBudsClient/GalaxyBudsClient.csproj
+++ b/GalaxyBudsClient/GalaxyBudsClient.csproj
@@ -43,6 +43,7 @@
         <DefineConstants>OSX</DefineConstants>
         <RuntimeIdentifiers>osx-x64;osx-arm64</RuntimeIdentifiers>
         <_XSAppIconAssets>Assets.xcassets/AppIcon.appiconset</_XSAppIconAssets>
+        <ApplicationVersion>$(Version)</ApplicationVersion>
     </PropertyGroup>
     <PropertyGroup Condition="'$(IsLinux)'=='true'">
         <DefineConstants>Linux</DefineConstants>

--- a/GalaxyBudsClient/Interface/Dialogs/BudsPopup.xaml
+++ b/GalaxyBudsClient/Interface/Dialogs/BudsPopup.xaml
@@ -18,6 +18,9 @@
         Icon="/Resources/icon_white.ico"
         ShowInTaskbar="False"
         Topmost="True"
+        ShowActivated="False"
+        IsEnabled="False"
+        Focusable="False"
         Title="Galaxy Buds Manager (Popup)"
         PointerPressed="Window_OnPointerPressed">
     <Border x:Name="OuterBorder"

--- a/GalaxyBudsClient/Interface/Dialogs/BudsPopup.xaml.cs
+++ b/GalaxyBudsClient/Interface/Dialogs/BudsPopup.xaml.cs
@@ -9,7 +9,6 @@ using Avalonia.Media;
 using Avalonia.Threading;
 using GalaxyBudsClient.Message;
 using GalaxyBudsClient.Message.Decoder;
-using GalaxyBudsClient.Model;
 using GalaxyBudsClient.Model.Constants;
 using GalaxyBudsClient.Model.Specifications;
 using GalaxyBudsClient.Platform;
@@ -141,8 +140,6 @@ namespace GalaxyBudsClient.Interface.Dialogs
         public override void Show()
         {
             base.Show();
-            Activate();
-            Focus();
             
             UpdateSettings();
             _outerBorder.Tag = "showing";

--- a/GalaxyBudsClient/Interface/Pages/SystemPage.xaml.cs
+++ b/GalaxyBudsClient/Interface/Pages/SystemPage.xaml.cs
@@ -66,7 +66,6 @@ namespace GalaxyBudsClient.Interface.Pages
         
         private async void Firmware_OnPointerPressed(object? sender, PointerPressedEventArgs e)
         {
-#if !OSX
             if (!SettingsProvider.Instance.FirmwareWarningAccepted)
             {
                 var result = await new QuestionBox()
@@ -87,15 +86,6 @@ namespace GalaxyBudsClient.Interface.Pages
             {
                 MainWindow.Instance.Pager.SwitchPage(Pages.FirmwareSelect);
             }
-#else
-            // at time of writing, OSX suffers from random, frequent SEGFAULTs and connection issues
-            // don't allow anyone to shoot themselves in their own foot until its absolutely 100% stable
-            await new MessageBox()
-            {
-                Title = "Firmware update",
-                Description = "Firmware update is not supported in the OSX port for now, it is too unstable!!",
-            }.ShowDialog<bool>(MainWindow.Instance);
-#endif
         }
 
         private void SpatialSensor_OnPointerPressed(object? sender, PointerPressedEventArgs e)

--- a/GalaxyBudsClient/MainWindow.xaml
+++ b/GalaxyBudsClient/MainWindow.xaml
@@ -18,7 +18,7 @@
         SystemDecorations="None"
         Background="Transparent"
         UseLayoutRounding="True"
-        Icon="Resources/icon_white.ico"
+        Icon="/Resources/icon_white.ico"
         Title="Galaxy Buds Manager">
     
     <Border CornerRadius="{StaticResource DefaultCornerRadius}"

--- a/ThePBone.OSX.Native/ThePBone.OSX.Native.csproj
+++ b/ThePBone.OSX.Native/ThePBone.OSX.Native.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;netstandard2.1</TargetFrameworks>
+        <TargetFramework>net8.0-macos</TargetFramework>
         <nullable>enable</nullable>
         <Configurations>Debug;Release;Debug (Local server)</Configurations>
         <Platforms>AnyCPU</Platforms>
@@ -48,10 +48,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Avalonia" Version="0.10.0" />
-      <PackageReference Include="Avalonia.Desktop" Version="0.10.0" />
-      <PackageReference Include="Serilog" Version="2.10.1-dev-01308" />
-      <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0-dev-00839" />
+      <PackageReference Include="Serilog" Version="3.1.1" />
     </ItemGroup>
     <ItemGroup>
       <None Remove="Native\Build\NativeInterop.build\Release\NativeInterop.build\Objects-normal\arm64\BluetoothDeviceWatcher.d" />

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "8.0.0",
+    "rollForward": "latestMajor",
+    "allowPrerelease": false
+  }
+}


### PR DESCRIPTION
Fixes:
1. macOS hotkey editor uses physical QWERTY key labels on all layouts (though it does also press the same key)

    This is unblocked by Avalonia 11 upgrade
    macOS code already exists and ~~just needs to be~~ now is uncommented: https://github.com/ThePBone/GalaxyBudsClient/blob/d48faff0118538887f4f5beb4854507bda9afb92/ThePBone.OSX.Native/Native/src/HotkeyManager.swift#L394-L403

2. Generated installer .PKG file has version 1.0
3. If Galaxy Buds Manager main window is open and NOT minimized-to-tray, and battery info popup closes, the main window will go to front
4. Firmware updates are untested, and hence disabled. -> They are now enabled, but untested anyways.