### PR TITLE
Fix another bunch of macOS bugs

### DIFF
--- a/GalaxyBudsClient/Interface/Dialogs/HotkeyActionBuilder.xaml.cs
+++ b/GalaxyBudsClient/Interface/Dialogs/HotkeyActionBuilder.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
@@ -223,6 +224,15 @@ namespace GalaxyBudsClient.Interface.Dialogs
         private void Action_OnSelectionChanged(object? sender, SelectionChangedEventArgs e)
         {
             UpdateKeyCombo();
+        }
+
+        public new async Task ShowDialog(Window owner)
+        {
+            await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(async () =>
+            {
+                await Task.Delay(300);
+                await base.ShowDialog(owner);
+            });
         }
     }
 }

--- a/GalaxyBudsClient/Interface/Dialogs/HotkeyRecorder.xaml.cs
+++ b/GalaxyBudsClient/Interface/Dialogs/HotkeyRecorder.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
@@ -74,6 +75,15 @@ namespace GalaxyBudsClient.Interface.Dialogs
                 Result = false;
             }
             base.OnClosed(e);
+        }
+
+        public new async Task ShowDialog(Window owner)
+        {
+            await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(async () =>
+            {
+                await Task.Delay(300);
+                await base.ShowDialog(owner);
+            });
         }
     }
 }

--- a/GalaxyBudsClient/Interface/Dialogs/InputDialog.xaml.cs
+++ b/GalaxyBudsClient/Interface/Dialogs/InputDialog.xaml.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
@@ -15,6 +16,15 @@ namespace GalaxyBudsClient.Interface.Dialogs
             this.AttachDevTools();
 
             Input = this.FindControl<TextBox>("Input");
+        }
+
+        public new async Task<TResult> ShowDialog<TResult>(Window owner)
+        {
+            return await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(async () =>
+            {
+                await Task.Delay(300);
+                return await base.ShowDialog<TResult>(owner);
+            });
         }
         
         private void Cancel_OnClick(object? sender, RoutedEventArgs e)

--- a/GalaxyBudsClient/Interface/Dialogs/ManualPairDialog.xaml.cs
+++ b/GalaxyBudsClient/Interface/Dialogs/ManualPairDialog.xaml.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
@@ -39,6 +40,15 @@ namespace GalaxyBudsClient.Interface.Dialogs
             Model = this.FindControl<ComboBox>("Model");
             
             Init();
+        }
+
+        public new async Task<TResult> ShowDialog<TResult>(Window owner)
+        {
+            return await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(async () =>
+            {
+                await Task.Delay(300);
+                return await base.ShowDialog<TResult>(owner);
+            });
         }
 
         private async void Init()

--- a/GalaxyBudsClient/Interface/Dialogs/MessageBox.xaml.cs
+++ b/GalaxyBudsClient/Interface/Dialogs/MessageBox.xaml.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
@@ -21,7 +22,16 @@ namespace GalaxyBudsClient.Interface.Dialogs
             DataContext = this;
             AvaloniaXamlLoader.Load(this);
         }
-        
+
+        public new Task ShowDialog(Window owner)
+        {
+            return Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(async () =>
+            {
+                await Task.Delay(300);
+                await base.ShowDialog(owner);
+            });
+        }
+
         private void Apply_OnClick(object? sender, RoutedEventArgs e)
         {
             Close();

--- a/GalaxyBudsClient/Interface/Dialogs/QuestionBox.xaml.cs
+++ b/GalaxyBudsClient/Interface/Dialogs/QuestionBox.xaml.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
@@ -20,6 +21,15 @@ namespace GalaxyBudsClient.Interface.Dialogs
         {
             DataContext = this;
             AvaloniaXamlLoader.Load(this);
+        }
+
+        public new async Task<TResult> ShowDialog<TResult>(Window owner)
+        {
+            return await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(async () =>
+            {
+                await Task.Delay(300);
+                return await base.ShowDialog<TResult>(owner);
+            });
         }
         
         private void Apply_OnClick(object? sender, RoutedEventArgs e)

--- a/GalaxyBudsClient/Interface/Pages/DeviceSelectionPage.xaml.cs
+++ b/GalaxyBudsClient/Interface/Pages/DeviceSelectionPage.xaml.cs
@@ -92,14 +92,13 @@ namespace GalaxyBudsClient.Interface.Pages
         {
             Avalonia.Threading.Dispatcher.UIThread.Post(async () =>
             {
-                await Task.Delay(300);
                 var dialog = new ManualPairDialog();
                 var accepted = await dialog.ShowDialog<bool>(MainWindow.Instance);
                 if (accepted)
                 {
                     if (dialog.SelectedModel == Models.NULL || dialog.SelectedDeviceMac == null)
                     {
-                        ShowErrorDialogSafely();
+                        ShowErrorDialog();
                         return;
                     }
                 
@@ -113,7 +112,7 @@ namespace GalaxyBudsClient.Interface.Pages
             
             if (Selection is not { Count: > 0 } || Selection.SelectedItem == null)
             {
-                ShowErrorDialogSafely();
+                ShowErrorDialog();
                 return;
             }
 
@@ -122,25 +121,20 @@ namespace GalaxyBudsClient.Interface.Pages
 
             if (spec == null || selection.IsConnected == false || selection.Address == string.Empty)
             {
-                ShowErrorDialogSafely();
+                ShowErrorDialog();
                 return;
             }
 
             RegisterDevice(spec.Device, selection.Address);
         }
 
-        // Workaround for Avalonia 11 focusing bug
-        private static void ShowErrorDialogSafely()
+        private static void ShowErrorDialog()
         {
-            Avalonia.Threading.Dispatcher.UIThread.Post(async () =>
+            new MessageBox()
             {
-                await Task.Delay(300);
-                await new MessageBox()
-                {
-                    Title = Loc.Resolve("error"),
-                    Description = Loc.Resolve("devsel_invalid_selection")
-                }.ShowDialog(MainWindow.Instance);
-            });
+                Title = Loc.Resolve("error"),
+                Description = Loc.Resolve("devsel_invalid_selection")
+            }.ShowDialog(MainWindow.Instance);
         }
 
         private async void RegisterDevice(Models model, string mac)

--- a/ThePBone.OSX.Native/Native/src/HotkeyManager.swift
+++ b/ThePBone.OSX.Native/Native/src/HotkeyManager.swift
@@ -200,10 +200,10 @@ import Magnet
         case .OemComma: .comma
         case .OemMinus: .minus
         case .OemPeriod: .period
-        // case .OemQuestion:
-        // case .OemTilde:
+        case .OemQuestion: .slash
+        case .OemTilde: .grave
         case .OemOpenBrackets: .leftBracket
-        // case .OemPipe:
+        case .OemPipe: .section
         case .OemCloseBrackets: .rightBracket
         case .OemQuotes: .quote
         // case .Oem8:
@@ -377,10 +377,10 @@ import Magnet
         // case .OemComma: .comma
         // case .OemMinus: .minus
         // case .OemPeriod: .period
-        // case .OemQuestion:
-        // case .OemTilde:
+        // case .OemQuestion: .slash
+        // case .OemTilde: .grave
         // case .OemOpenBrackets: .leftBracket
-        // case .OemPipe:
+        // case .OemPipe: .section
         // case .OemCloseBrackets: .rightBracket
         // case .OemQuotes: .quote
         // case .Oem8:


### PR DESCRIPTION
Fixes:

1. macOS hotkey dispatching does not support 100% of keys
  - Not everything seems to match perfectly (exist on both keyboards) between Win32/Avalonia keycodes and macOS keycodes
  - -> how does Avalonia map these keys?
  - https://github.com/ThePBone/GalaxyBudsClient/blob/d48faff0118538887f4f5beb4854507bda9afb92/ThePBone.OSX.Native/Native/src/HotkeyManager.swift#L53-L214
2. If you open any UI dialog (in the whole app), examples being "Override popup title" in settings, and closing it again, the either main window will open the dialog again on a click anywhere and will highlight the button if the mouse hovers over the window, and you have to restart the app to click anything else / get out.