### PR TITLE
Add macOS CI

### DIFF
--- a/.github/workflows/compile-macos.yml
+++ b/.github/workflows/compile-macos.yml
@@ -1,0 +1,115 @@
+name: Compile macOS binaries
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  release:
+     types: 
+       - published
+       - prereleased
+  workflow_dispatch:
+
+jobs:
+  build-x64:
+    runs-on: macos-14
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup Xcode
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: '15.2'
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.101
+        
+    - name: Build NativeInterop.xcodeproj
+      uses: sersoft-gmbh/xcodebuild-action@v3
+      with:
+        project: ThePBone.OSX.Native/Native/NativeInterop.xcodeproj
+        scheme: NativeInterop
+        destination: platform=macOS,arch=x86_64
+        build-settings: CONFIGURATION_BUILD_DIR=/Users/runner/work/GalaxyBudsClient/GalaxyBudsClient/ThePBone.OSX.Native/Native/Build/Release CONFIGURATION_TEMP_DIR=/Users/runner/work/GalaxyBudsClient/GalaxyBudsClient/ThePBone.OSX.Native/Native/Build/Intermediates.noindex
+        action: build
+       
+    - name: Restore workloads
+      run: dotnet workload restore
+    - name: Restore dependencies
+      run: dotnet restore -r osx-x64 --configfile GalaxyBudsClient/nuget.config GalaxyBudsClient/GalaxyBudsClient.csproj
+    - name: Build x64
+      run: dotnet publish -r osx-x64 -o bin_osxx64 -c Release --no-restore GalaxyBudsClient/GalaxyBudsClient.csproj
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: GalaxyBudsClient_osx-x64
+        path: bin_osxx64/GalaxyBudsClient-*.pkg
+
+  build-arm64:
+    runs-on: macos-14
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup Xcode
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: '15.2'
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.101
+        
+    - name: Build NativeInterop.xcodeproj
+      uses: sersoft-gmbh/xcodebuild-action@v3
+      with:
+        project: ThePBone.OSX.Native/Native/NativeInterop.xcodeproj
+        scheme: NativeInterop
+        destination: platform=macOS,arch=arm64
+        build-settings: CONFIGURATION_BUILD_DIR=/Users/runner/work/GalaxyBudsClient/GalaxyBudsClient/ThePBone.OSX.Native/Native/Build/Release CONFIGURATION_TEMP_DIR=/Users/runner/work/GalaxyBudsClient/GalaxyBudsClient/ThePBone.OSX.Native/Native/Build/Intermediates.noindex
+        action: build
+
+    - name: Restore workloads
+      run: dotnet workload restore
+    - name: Restore dependencies
+      run: dotnet restore -r osx-arm64 --configfile GalaxyBudsClient/nuget.config GalaxyBudsClient/GalaxyBudsClient.csproj
+    - name: Build arm64
+      run: dotnet publish -r osx-arm64 -o bin_osxarm64 -c Release --no-restore GalaxyBudsClient/GalaxyBudsClient.csproj
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: GalaxyBudsClient_osx-arm64
+        path: bin_osxarm64/GalaxyBudsClient-*.pkg
+
+
+  attach-to-release:
+    runs-on: ubuntu-latest
+    needs: [build-x64, build-arm64]
+    if: github.event_name == 'release'
+     
+    steps:
+    - name: Download setup artifact (x64)
+      uses: actions/download-artifact@v3
+      with:
+        name: GalaxyBudsClient_osx-x64
+    
+    - name: Rename (x64)
+      run: mv GalaxyBudsClient-*.pkg GalaxyBudsClient_macOS_x64.pkg
+
+    - name: Download artifact (arm64)
+      uses: actions/download-artifact@v3
+      with:
+        name: GalaxyBudsClient_osx-arm64
+
+    - name: Rename (arm64)
+      run: mv GalaxyBudsClient-*.pkg GalaxyBudsClient_macOS_arm64.pkg
+
+    - uses: AButler/upload-release-assets@v2.0
+      with:
+        files: '*.pkg'
+        repo-token: ${{ secrets.GH_TOKEN }}

--- a/GalaxyBudsClient/GalaxyBudsClient.csproj
+++ b/GalaxyBudsClient/GalaxyBudsClient.csproj
@@ -44,6 +44,7 @@
         <RuntimeIdentifiers>osx-x64;osx-arm64</RuntimeIdentifiers>
         <_XSAppIconAssets>Assets.xcassets/AppIcon.appiconset</_XSAppIconAssets>
         <ApplicationVersion>$(Version)</ApplicationVersion>
+	<SupportedOSPlatformVersion>12.0</SupportedOSPlatformVersion>
     </PropertyGroup>
     <PropertyGroup Condition="'$(IsLinux)'=='true'">
         <DefineConstants>Linux</DefineConstants>

--- a/GalaxyBudsClient/GalaxyBudsClient.csproj
+++ b/GalaxyBudsClient/GalaxyBudsClient.csproj
@@ -85,14 +85,14 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.0.7" />
-        <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.0.7" />
-        <PackageReference Include="Avalonia.Desktop" Version="11.0.7" />
-        <PackageReference Include="Avalonia.Diagnostics" Version="11.0.7" />
-        <PackageReference Include="Avalonia.Fonts.Inter" Version="11.0.7" />
-        <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="11.0.7" />
+        <PackageReference Include="Avalonia" Version="11.0.8" />
+        <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.0.8" />
+        <PackageReference Include="Avalonia.Desktop" Version="11.0.8" />
+        <PackageReference Include="Avalonia.Diagnostics" Version="11.0.8" />
+        <PackageReference Include="Avalonia.Fonts.Inter" Version="11.0.8" />
+        <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="11.0.8" />
         <PackageReference Include="Avalonia.Svg.Skia" Version="11.0.0.13" />
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.7" />
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.8" />
         <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.0.6" />
         <PackageReference Include="Config.Net" Version="5.1.5" />
         <PackageReference Include="CS-Script.Core" Version="2.0.0" />

--- a/ThePBone.OSX.Native/Native/NativeInterop.xcodeproj/project.pbxproj
+++ b/ThePBone.OSX.Native/Native/NativeInterop.xcodeproj/project.pbxproj
@@ -3,150 +3,158 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 56;
 	objects = {
 
 /* Begin PBXBuildFile section */
-		015D13832B6E845000D342D8 /* HotkeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 015D13822B6E845000D342D8 /* HotkeyManager.swift */; };
-		015D13852B6E852A00D342D8 /* Magnet in Frameworks */ = {isa = PBXBuildFile; productRef = 015D13842B6E852A00D342D8 /* Magnet */; };
-		01C1987F2B6D8F0C009EEA07 /* Native.AppUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = 01C1987E2B6D8F0C009EEA07 /* Native.AppUtils.mm */; };
-		01C198812B6D9023009EEA07 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 01C198802B6D9023009EEA07 /* AppKit.framework */; };
-		01C198842B6D9C9E009EEA07 /* LaunchAtLoginController.m in Sources */ = {isa = PBXBuildFile; fileRef = 01C198832B6D9C9E009EEA07 /* LaunchAtLoginController.m */; };
-		01F5A1C32B6EB04F001B8206 /* NIBridge.mm in Sources */ = {isa = PBXBuildFile; fileRef = 01F5A1C22B6EB04F001B8206 /* NIBridge.mm */; };
-		01F5A1C52B6EB150001B8206 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 01F5A1C42B6EB150001B8206 /* Foundation.framework */; };
-		1C0983CB4A36B117AF41155E /* Bluetooth.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C098F273A7E24715983E630 /* Bluetooth.mm */; };
-		1C0989E232D8E7E0534F2834 /* BluetoothDeviceWatcher.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C098325C88AD4809959EDBE /* BluetoothDeviceWatcher.mm */; };
-		1C098AE4A9BA02B8EDE3DA5B /* Native.Bluetooth.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C098B72451782C32C519A71 /* Native.Bluetooth.mm */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		1C098CEE45D021CBF857A569 /* Native.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C0984E6D93230E41397FA0D /* Native.h */; };
-		1C098D2FA9AEC3B92E0EA09D /* Bluetooth.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C09879DB3B0035983B5B99A /* Bluetooth.h */; };
-		1C098E958CA148B20DCB4F6D /* BluetoothDeviceWatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C098B5CA5C8E76FE0849D49 /* BluetoothDeviceWatcher.h */; };
-		1C098FD7AF270DE474ED52EB /* Native.Memory.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C098422B9BFF59462222A36 /* Native.Memory.mm */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		2276033B2651CDB000D756A8 /* IOBluetooth.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2276033A2651CDB000D756A8 /* IOBluetooth.framework */; };
+		0182643F2B7655F6009DDEDE /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0182643E2B7655F6009DDEDE /* AppKit.framework */; };
+		018264412B765604009DDEDE /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 018264402B765604009DDEDE /* Foundation.framework */; };
+		018264432B76560B009DDEDE /* IOBluetooth.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 018264422B76560B009DDEDE /* IOBluetooth.framework */; };
+		018264762B7656DD009DDEDE /* BluetoothDeviceWatcher.mm in Sources */ = {isa = PBXBuildFile; fileRef = 018264662B7656DD009DDEDE /* BluetoothDeviceWatcher.mm */; };
+		018264772B7656DD009DDEDE /* LaunchAtLoginController.m in Sources */ = {isa = PBXBuildFile; fileRef = 018264672B7656DD009DDEDE /* LaunchAtLoginController.m */; };
+		018264782B7656DD009DDEDE /* Bluetooth.mm in Sources */ = {isa = PBXBuildFile; fileRef = 018264682B7656DD009DDEDE /* Bluetooth.mm */; };
+		018264792B7656DD009DDEDE /* Native.Memory.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0182646A2B7656DD009DDEDE /* Native.Memory.mm */; };
+		0182647A2B7656DD009DDEDE /* Native.Bluetooth.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0182646B2B7656DD009DDEDE /* Native.Bluetooth.mm */; };
+		0182647B2B7656DD009DDEDE /* Native.AppUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0182646C2B7656DD009DDEDE /* Native.AppUtils.mm */; };
+		0182647C2B7656DD009DDEDE /* HotkeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0182646D2B7656DD009DDEDE /* HotkeyManager.swift */; };
+		0182647D2B7656DD009DDEDE /* Bluetooth.h in Headers */ = {isa = PBXBuildFile; fileRef = 0182646E2B7656DD009DDEDE /* Bluetooth.h */; };
+		0182647E2B7656DD009DDEDE /* NIBridge.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0182646F2B7656DD009DDEDE /* NIBridge.mm */; };
+		0182647F2B7656DD009DDEDE /* LaunchAtLoginController.h in Headers */ = {isa = PBXBuildFile; fileRef = 018264702B7656DD009DDEDE /* LaunchAtLoginController.h */; };
+		018264802B7656DD009DDEDE /* NIBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = 018264712B7656DD009DDEDE /* NIBridge.h */; };
+		018264812B7656DD009DDEDE /* NativeInterop-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 018264722B7656DD009DDEDE /* NativeInterop-Bridging-Header.h */; };
+		018264822B7656DD009DDEDE /* BluetoothDeviceWatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 018264732B7656DD009DDEDE /* BluetoothDeviceWatcher.h */; };
+		018264832B7656DD009DDEDE /* Native.h in Headers */ = {isa = PBXBuildFile; fileRef = 018264752B7656DD009DDEDE /* Native.h */; };
+		0194D8F52B7650E000B647DB /* Magnet in Frameworks */ = {isa = PBXBuildFile; productRef = 0194D8F42B7650E000B647DB /* Magnet */; };
+		0194D8F82B7650FC00B647DB /* Sauce in Frameworks */ = {isa = PBXBuildFile; productRef = 0194D8F72B7650FC00B647DB /* Sauce */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		015D13812B6E845000D342D8 /* NativeInterop-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NativeInterop-Bridging-Header.h"; sourceTree = "<group>"; };
-		015D13822B6E845000D342D8 /* HotkeyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyManager.swift; sourceTree = "<group>"; };
-		01C1987E2B6D8F0C009EEA07 /* Native.AppUtils.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = Native.AppUtils.mm; sourceTree = "<group>"; };
-		01C198802B6D9023009EEA07 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
-		01C198822B6D9C7F009EEA07 /* LaunchAtLoginController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LaunchAtLoginController.h; sourceTree = "<group>"; };
-		01C198832B6D9C9E009EEA07 /* LaunchAtLoginController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LaunchAtLoginController.m; sourceTree = "<group>"; };
-		01F5A1C22B6EB04F001B8206 /* NIBridge.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = NIBridge.mm; sourceTree = "<group>"; };
-		01F5A1C42B6EB150001B8206 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
-		01F6DD892B6EAC56008A2A4F /* NIBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NIBridge.h; sourceTree = "<group>"; };
-		1C098325C88AD4809959EDBE /* BluetoothDeviceWatcher.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = BluetoothDeviceWatcher.mm; sourceTree = "<group>"; };
-		1C098422B9BFF59462222A36 /* Native.Memory.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = Native.Memory.mm; sourceTree = "<group>"; };
-		1C0984E6D93230E41397FA0D /* Native.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Native.h; sourceTree = "<group>"; };
-		1C09879DB3B0035983B5B99A /* Bluetooth.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Bluetooth.h; sourceTree = "<group>"; };
-		1C09896C4A560632CA6CF376 /* libNativeInterop.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libNativeInterop.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
-		1C098B5CA5C8E76FE0849D49 /* BluetoothDeviceWatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BluetoothDeviceWatcher.h; sourceTree = "<group>"; };
-		1C098B72451782C32C519A71 /* Native.Bluetooth.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = Native.Bluetooth.mm; sourceTree = "<group>"; };
-		1C098F273A7E24715983E630 /* Bluetooth.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = Bluetooth.mm; sourceTree = "<group>"; };
-		2276033A2651CDB000D756A8 /* IOBluetooth.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOBluetooth.framework; path = System/Library/Frameworks/IOBluetooth.framework; sourceTree = SDKROOT; };
+		0182643E2B7655F6009DDEDE /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
+		018264402B765604009DDEDE /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		018264422B76560B009DDEDE /* IOBluetooth.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOBluetooth.framework; path = System/Library/Frameworks/IOBluetooth.framework; sourceTree = SDKROOT; };
+		018264662B7656DD009DDEDE /* BluetoothDeviceWatcher.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = BluetoothDeviceWatcher.mm; sourceTree = "<group>"; };
+		018264672B7656DD009DDEDE /* LaunchAtLoginController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LaunchAtLoginController.m; sourceTree = "<group>"; };
+		018264682B7656DD009DDEDE /* Bluetooth.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = Bluetooth.mm; sourceTree = "<group>"; };
+		0182646A2B7656DD009DDEDE /* Native.Memory.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = Native.Memory.mm; sourceTree = "<group>"; };
+		0182646B2B7656DD009DDEDE /* Native.Bluetooth.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = Native.Bluetooth.mm; sourceTree = "<group>"; };
+		0182646C2B7656DD009DDEDE /* Native.AppUtils.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = Native.AppUtils.mm; sourceTree = "<group>"; };
+		0182646D2B7656DD009DDEDE /* HotkeyManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HotkeyManager.swift; sourceTree = "<group>"; };
+		0182646E2B7656DD009DDEDE /* Bluetooth.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Bluetooth.h; sourceTree = "<group>"; };
+		0182646F2B7656DD009DDEDE /* NIBridge.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = NIBridge.mm; sourceTree = "<group>"; };
+		018264702B7656DD009DDEDE /* LaunchAtLoginController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LaunchAtLoginController.h; sourceTree = "<group>"; };
+		018264712B7656DD009DDEDE /* NIBridge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NIBridge.h; sourceTree = "<group>"; };
+		018264722B7656DD009DDEDE /* NativeInterop-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NativeInterop-Bridging-Header.h"; sourceTree = "<group>"; };
+		018264732B7656DD009DDEDE /* BluetoothDeviceWatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BluetoothDeviceWatcher.h; sourceTree = "<group>"; };
+		018264752B7656DD009DDEDE /* Native.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Native.h; sourceTree = "<group>"; };
+		0184E2F62B76502D00875BB7 /* libNativeInterop.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libNativeInterop.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		1C0989DF3D3B6BB25C5A4532 /* Frameworks */ = {
+		0184E2F42B76502D00875BB7 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				01C198812B6D9023009EEA07 /* AppKit.framework in Frameworks */,
-				015D13852B6E852A00D342D8 /* Magnet in Frameworks */,
-				2276033B2651CDB000D756A8 /* IOBluetooth.framework in Frameworks */,
-				01F5A1C52B6EB150001B8206 /* Foundation.framework in Frameworks */,
+				0182643F2B7655F6009DDEDE /* AppKit.framework in Frameworks */,
+				0194D8F82B7650FC00B647DB /* Sauce in Frameworks */,
+				0194D8F52B7650E000B647DB /* Magnet in Frameworks */,
+				018264412B765604009DDEDE /* Foundation.framework in Frameworks */,
+				018264432B76560B009DDEDE /* IOBluetooth.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		1C0986D6038D35A3E0088401 = {
+		0182643D2B7655F6009DDEDE /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				1C098846E0A1E463C39CF74F /* Products */,
-				1C098F4E31B5C740FB51BB0F /* src */,
-				1C09892EFD59C21B32D31777 /* include */,
-				227603392651CDB000D756A8 /* Frameworks */,
+				018264422B76560B009DDEDE /* IOBluetooth.framework */,
+				018264402B765604009DDEDE /* Foundation.framework */,
+				0182643E2B7655F6009DDEDE /* AppKit.framework */,
 			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		1C098846E0A1E463C39CF74F /* Products */ = {
+		018264652B7656DD009DDEDE /* src */ = {
 			isa = PBXGroup;
 			children = (
-				1C09896C4A560632CA6CF376 /* libNativeInterop.dylib */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		1C09892EFD59C21B32D31777 /* include */ = {
-			isa = PBXGroup;
-			children = (
-				1C0984E6D93230E41397FA0D /* Native.h */,
-			);
-			path = include;
-			sourceTree = "<group>";
-		};
-		1C098C4BB6B054DCFF1D9264 /* bridge */ = {
-			isa = PBXGroup;
-			children = (
-				01C1987E2B6D8F0C009EEA07 /* Native.AppUtils.mm */,
-				1C098422B9BFF59462222A36 /* Native.Memory.mm */,
-				1C098B72451782C32C519A71 /* Native.Bluetooth.mm */,
-			);
-			path = bridge;
-			sourceTree = "<group>";
-		};
-		1C098F4E31B5C740FB51BB0F /* src */ = {
-			isa = PBXGroup;
-			children = (
-				1C09879DB3B0035983B5B99A /* Bluetooth.h */,
-				1C098F273A7E24715983E630 /* Bluetooth.mm */,
-				1C098325C88AD4809959EDBE /* BluetoothDeviceWatcher.mm */,
-				1C098B5CA5C8E76FE0849D49 /* BluetoothDeviceWatcher.h */,
-				1C098C4BB6B054DCFF1D9264 /* bridge */,
-				01C198822B6D9C7F009EEA07 /* LaunchAtLoginController.h */,
-				01C198832B6D9C9E009EEA07 /* LaunchAtLoginController.m */,
-				015D13822B6E845000D342D8 /* HotkeyManager.swift */,
-				015D13812B6E845000D342D8 /* NativeInterop-Bridging-Header.h */,
-				01F6DD892B6EAC56008A2A4F /* NIBridge.h */,
-				01F5A1C22B6EB04F001B8206 /* NIBridge.mm */,
+				018264662B7656DD009DDEDE /* BluetoothDeviceWatcher.mm */,
+				018264672B7656DD009DDEDE /* LaunchAtLoginController.m */,
+				018264682B7656DD009DDEDE /* Bluetooth.mm */,
+				018264692B7656DD009DDEDE /* bridge */,
+				0182646D2B7656DD009DDEDE /* HotkeyManager.swift */,
+				0182646E2B7656DD009DDEDE /* Bluetooth.h */,
+				0182646F2B7656DD009DDEDE /* NIBridge.mm */,
+				018264702B7656DD009DDEDE /* LaunchAtLoginController.h */,
+				018264712B7656DD009DDEDE /* NIBridge.h */,
+				018264722B7656DD009DDEDE /* NativeInterop-Bridging-Header.h */,
+				018264732B7656DD009DDEDE /* BluetoothDeviceWatcher.h */,
 			);
 			path = src;
 			sourceTree = "<group>";
 		};
-		227603392651CDB000D756A8 /* Frameworks */ = {
+		018264692B7656DD009DDEDE /* bridge */ = {
 			isa = PBXGroup;
 			children = (
-				01F5A1C42B6EB150001B8206 /* Foundation.framework */,
-				01C198802B6D9023009EEA07 /* AppKit.framework */,
-				2276033A2651CDB000D756A8 /* IOBluetooth.framework */,
+				0182646A2B7656DD009DDEDE /* Native.Memory.mm */,
+				0182646B2B7656DD009DDEDE /* Native.Bluetooth.mm */,
+				0182646C2B7656DD009DDEDE /* Native.AppUtils.mm */,
 			);
-			name = Frameworks;
+			path = bridge;
+			sourceTree = "<group>";
+		};
+		018264742B7656DD009DDEDE /* include */ = {
+			isa = PBXGroup;
+			children = (
+				018264752B7656DD009DDEDE /* Native.h */,
+			);
+			path = include;
+			sourceTree = "<group>";
+		};
+		0184E2ED2B76502D00875BB7 = {
+			isa = PBXGroup;
+			children = (
+				018264742B7656DD009DDEDE /* include */,
+				018264652B7656DD009DDEDE /* src */,
+				0184E2F72B76502D00875BB7 /* Products */,
+				0182643D2B7655F6009DDEDE /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		0184E2F72B76502D00875BB7 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				0184E2F62B76502D00875BB7 /* libNativeInterop.dylib */,
+			);
+			name = Products;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		1C098BE86AD9A483455FA215 /* Headers */ = {
+		0184E2F22B76502D00875BB7 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1C098D2FA9AEC3B92E0EA09D /* Bluetooth.h in Headers */,
-				1C098CEE45D021CBF857A569 /* Native.h in Headers */,
-				1C098E958CA148B20DCB4F6D /* BluetoothDeviceWatcher.h in Headers */,
+				018264802B7656DD009DDEDE /* NIBridge.h in Headers */,
+				0182647F2B7656DD009DDEDE /* LaunchAtLoginController.h in Headers */,
+				018264812B7656DD009DDEDE /* NativeInterop-Bridging-Header.h in Headers */,
+				018264832B7656DD009DDEDE /* Native.h in Headers */,
+				0182647D2B7656DD009DDEDE /* Bluetooth.h in Headers */,
+				018264822B7656DD009DDEDE /* BluetoothDeviceWatcher.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		1C098FD2EFC95C46A8BD2F9B /* NativeInterop */ = {
+		0184E2F52B76502D00875BB7 /* NativeInterop */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 1C098C20BB23AA8934D77F5B /* Build configuration list for PBXNativeTarget "NativeInterop" */;
+			buildConfigurationList = 0184E2FF2B76502D00875BB7 /* Build configuration list for PBXNativeTarget "NativeInterop" */;
 			buildPhases = (
-				1C098BE86AD9A483455FA215 /* Headers */,
-				1C0982AA8501763AEDE5F18D /* Sources */,
-				1C0989DF3D3B6BB25C5A4532 /* Frameworks */,
+				0184E2F22B76502D00875BB7 /* Headers */,
+				0184E2F32B76502D00875BB7 /* Sources */,
+				0184E2F42B76502D00875BB7 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -154,75 +162,77 @@
 			);
 			name = NativeInterop;
 			packageProductDependencies = (
-				015D13842B6E852A00D342D8 /* Magnet */,
+				0194D8F42B7650E000B647DB /* Magnet */,
+				0194D8F72B7650FC00B647DB /* Sauce */,
 			);
-			productName = NativeInterop;
-			productReference = 1C09896C4A560632CA6CF376 /* libNativeInterop.dylib */;
+			productName = libNativeInterop;
+			productReference = 0184E2F62B76502D00875BB7 /* libNativeInterop.dylib */;
 			productType = "com.apple.product-type.library.dynamic";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		1C0984D130776B708AC54F6D /* Project object */ = {
+		0184E2EE2B76502D00875BB7 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				BuildIndependentTargetsInParallel = YES;
+				BuildIndependentTargetsInParallel = 1;
 				LastUpgradeCheck = 1520;
-				ORGANIZATIONNAME = "Tim Schneeberger";
 				TargetAttributes = {
-					1C098FD2EFC95C46A8BD2F9B = {
+					0184E2F52B76502D00875BB7 = {
+						CreatedOnToolsVersion = 15.2;
 						LastSwiftMigration = 1520;
 					};
 				};
 			};
-			buildConfigurationList = 1C098E4A108E9474A6479BF4 /* Build configuration list for PBXProject "NativeInterop" */;
-			compatibilityVersion = "Xcode 12.0";
+			buildConfigurationList = 0184E2F12B76502D00875BB7 /* Build configuration list for PBXProject "NativeInterop" */;
+			compatibilityVersion = "Xcode 14.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
 				Base,
 			);
-			mainGroup = 1C0986D6038D35A3E0088401;
+			mainGroup = 0184E2ED2B76502D00875BB7;
 			packageReferences = (
-				01A76C032B6E7BAE004D46D6 /* XCRemoteSwiftPackageReference "Magnet" */,
+				0194D8F32B7650E000B647DB /* XCRemoteSwiftPackageReference "Magnet" */,
+				0194D8F62B7650FC00B647DB /* XCRemoteSwiftPackageReference "Sauce" */,
 			);
-			productRefGroup = 1C098846E0A1E463C39CF74F /* Products */;
+			productRefGroup = 0184E2F72B76502D00875BB7 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				1C098FD2EFC95C46A8BD2F9B /* NativeInterop */,
+				0184E2F52B76502D00875BB7 /* NativeInterop */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXSourcesBuildPhase section */
-		1C0982AA8501763AEDE5F18D /* Sources */ = {
+		0184E2F32B76502D00875BB7 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1C0983CB4A36B117AF41155E /* Bluetooth.mm in Sources */,
-				1C0989E232D8E7E0534F2834 /* BluetoothDeviceWatcher.mm in Sources */,
-				1C098FD7AF270DE474ED52EB /* Native.Memory.mm in Sources */,
-				01C198842B6D9C9E009EEA07 /* LaunchAtLoginController.m in Sources */,
-				1C098AE4A9BA02B8EDE3DA5B /* Native.Bluetooth.mm in Sources */,
-				015D13832B6E845000D342D8 /* HotkeyManager.swift in Sources */,
-				01C1987F2B6D8F0C009EEA07 /* Native.AppUtils.mm in Sources */,
-				01F5A1C32B6EB04F001B8206 /* NIBridge.mm in Sources */,
+				018264762B7656DD009DDEDE /* BluetoothDeviceWatcher.mm in Sources */,
+				0182647A2B7656DD009DDEDE /* Native.Bluetooth.mm in Sources */,
+				018264772B7656DD009DDEDE /* LaunchAtLoginController.m in Sources */,
+				0182647B2B7656DD009DDEDE /* Native.AppUtils.mm in Sources */,
+				018264792B7656DD009DDEDE /* Native.Memory.mm in Sources */,
+				0182647C2B7656DD009DDEDE /* HotkeyManager.swift in Sources */,
+				018264782B7656DD009DDEDE /* Bluetooth.mm in Sources */,
+				0182647E2B7656DD009DDEDE /* NIBridge.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
-		1C098074F924FC0864305F1E /* Debug */ = {
+		0184E2FD2B76502D00875BB7 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
-				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
@@ -248,15 +258,12 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGN_IDENTITY = "-";
-				CONFIGURATION_BUILD_DIR = Build/Debug;
 				COPY_PHASE_STRIP = NO;
-				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -270,27 +277,23 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_LDFLAGS = (
-					"-Xlinker",
-					"-v",
-				);
 				SDKROOT = macosx;
-				SYMROOT = Build;
 			};
 			name = Debug;
 		};
-		1C09827AF52EA0F761CAE858 /* Release */ = {
+		0184E2FE2B76502D00875BB7 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
-				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
@@ -316,15 +319,12 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGN_IDENTITY = "-";
-				CONFIGURATION_BUILD_DIR = Build/Release;
 				COPY_PHASE_STRIP = NO;
-				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
@@ -332,42 +332,23 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
-				OTHER_LDFLAGS = (
-					"-Xlinker",
-					"-v",
-				);
 				SDKROOT = macosx;
-				SYMROOT = Build;
 			};
 			name = Release;
 		};
-		1C098E88951D039B002D5EF3 /* Debug */ = {
+		0184E3002B76502D00875BB7 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				DEAD_CODE_STRIPPING = YES;
+				CODE_SIGN_STYLE = Automatic;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				EXECUTABLE_PREFIX = lib;
-				HEADER_SEARCH_PATHS = include/;
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				OTHER_CFLAGS = (
-					"-v",
-					"-fcxx-modules",
-					"-fmodules",
-				);
-				OTHER_CPLUSPLUSFLAGS = (
-					"$(OTHER_CFLAGS)",
-					"-fmodules",
-					"-fcxx-modules",
-				);
-				OTHER_LDFLAGS = (
-					"-Xlinker",
-					"-v",
-				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "src/NativeInterop-Bridging-Header.h";
@@ -376,30 +357,15 @@
 			};
 			name = Debug;
 		};
-		1C098E8DC44A098A7EEA933F /* Release */ = {
+		0184E3012B76502D00875BB7 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				DEAD_CODE_STRIPPING = YES;
+				CODE_SIGN_STYLE = Automatic;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				EXECUTABLE_PREFIX = lib;
-				HEADER_SEARCH_PATHS = include/;
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				OTHER_CFLAGS = (
-					"-v",
-					"-fcxx-modules",
-					"-fmodules",
-				);
-				OTHER_CPLUSPLUSFLAGS = (
-					"$(OTHER_CFLAGS)",
-					"-fmodules",
-					"-fcxx-modules",
-				);
-				OTHER_LDFLAGS = (
-					"-Xlinker",
-					"-v",
-				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "src/NativeInterop-Bridging-Header.h";
@@ -410,20 +376,20 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		1C098C20BB23AA8934D77F5B /* Build configuration list for PBXNativeTarget "NativeInterop" */ = {
+		0184E2F12B76502D00875BB7 /* Build configuration list for PBXProject "NativeInterop" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				1C098E88951D039B002D5EF3 /* Debug */,
-				1C098E8DC44A098A7EEA933F /* Release */,
+				0184E2FD2B76502D00875BB7 /* Debug */,
+				0184E2FE2B76502D00875BB7 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		1C098E4A108E9474A6479BF4 /* Build configuration list for PBXProject "NativeInterop" */ = {
+		0184E2FF2B76502D00875BB7 /* Build configuration list for PBXNativeTarget "NativeInterop" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				1C098074F924FC0864305F1E /* Debug */,
-				1C09827AF52EA0F761CAE858 /* Release */,
+				0184E3002B76502D00875BB7 /* Debug */,
+				0184E3012B76502D00875BB7 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -431,9 +397,17 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		01A76C032B6E7BAE004D46D6 /* XCRemoteSwiftPackageReference "Magnet" */ = {
+		0194D8F32B7650E000B647DB /* XCRemoteSwiftPackageReference "Magnet" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Clipy/Magnet";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
+		0194D8F62B7650FC00B647DB /* XCRemoteSwiftPackageReference "Sauce" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Clipy/Sauce";
 			requirement = {
 				branch = master;
 				kind = branch;
@@ -442,12 +416,17 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		015D13842B6E852A00D342D8 /* Magnet */ = {
+		0194D8F42B7650E000B647DB /* Magnet */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 01A76C032B6E7BAE004D46D6 /* XCRemoteSwiftPackageReference "Magnet" */;
+			package = 0194D8F32B7650E000B647DB /* XCRemoteSwiftPackageReference "Magnet" */;
 			productName = Magnet;
+		};
+		0194D8F72B7650FC00B647DB /* Sauce */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 0194D8F62B7650FC00B647DB /* XCRemoteSwiftPackageReference "Sauce" */;
+			productName = Sauce;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};
-	rootObject = 1C0984D130776B708AC54F6D /* Project object */;
+	rootObject = 0184E2EE2B76502D00875BB7 /* Project object */;
 }

--- a/ThePBone.OSX.Native/Native/NativeInterop.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ThePBone.OSX.Native/Native/NativeInterop.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Clipy/Sauce",
       "state" : {
-        "revision" : "8f8fabaa8509c1a653d6c2c3c87396a4c493d876",
-        "version" : "2.4.0"
+        "branch" : "master",
+        "revision" : "4fa210cc79207a9570b5620119f887fbdea99a06"
       }
     }
   ],

--- a/ThePBone.OSX.Native/Native/NativeInterop.xcodeproj/xcshareddata/xcschemes/NativeInterop.xcscheme
+++ b/ThePBone.OSX.Native/Native/NativeInterop.xcodeproj/xcshareddata/xcschemes/NativeInterop.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1C098FD2EFC95C46A8BD2F9B"
+               BlueprintIdentifier = "0184E2F52B76502D00875BB7"
                BuildableName = "libNativeInterop.dylib"
                BlueprintName = "NativeInterop"
                ReferencedContainer = "container:NativeInterop.xcodeproj">
@@ -49,7 +49,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "1C098FD2EFC95C46A8BD2F9B"
+            BlueprintIdentifier = "0184E2F52B76502D00875BB7"
             BuildableName = "libNativeInterop.dylib"
             BlueprintName = "NativeInterop"
             ReferencedContainer = "container:NativeInterop.xcodeproj">

--- a/ThePBone.OSX.Native/Native/src/HotkeyManager.swift
+++ b/ThePBone.OSX.Native/Native/src/HotkeyManager.swift
@@ -8,7 +8,7 @@
 import Foundation
 import AppKit
 import Carbon.HIToolbox
-import Sauce // for me, xcode claims there is "no such module" but build works fine
+import Sauce
 import Magnet
 
 // This briding class exists because Magnet package does not export classes into Obj-C

--- a/ThePBone.OSX.Native/ThePBone.OSX.Native.csproj
+++ b/ThePBone.OSX.Native/ThePBone.OSX.Native.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0-macos</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <nullable>enable</nullable>
         <Configurations>Debug;Release;Debug (Local server)</Configurations>
         <Platforms>AnyCPU</Platforms>


### PR DESCRIPTION
Fixes some build flakiness issues by regenerating Xcode project, ensures parameters like min OS version aren't dependant on build machine and then adds working x64+arm64 binaries to artifacts.