### PR TITLE
The final bunch of macOS fixes (for now)

### DIFF
--- a/.github/workflows/compile-macos.yml
+++ b/.github/workflows/compile-macos.yml
@@ -12,6 +12,43 @@ on:
   workflow_dispatch:
 
 jobs:
+  build-universal:
+    runs-on: macos-14
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup Xcode
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: '15.2'
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.101
+
+    - name: Build NativeInterop.xcodeproj
+      uses: sersoft-gmbh/xcodebuild-action@v3
+      with:
+        project: ThePBone.OSX.Native/Native/NativeInterop.xcodeproj
+        scheme: NativeInterop
+        destination: platform=macOS
+        build-settings: CONFIGURATION_BUILD_DIR=/Users/runner/work/GalaxyBudsClient/GalaxyBudsClient/ThePBone.OSX.Native/Native/Build/Release CONFIGURATION_TEMP_DIR=/Users/runner/work/GalaxyBudsClient/GalaxyBudsClient/ThePBone.OSX.Native/Native/Build/Intermediates.noindex
+        action: build
+
+    - name: Restore workloads
+      run: dotnet workload restore
+    - name: Restore dependencies
+      run: dotnet restore --configfile GalaxyBudsClient/nuget.config GalaxyBudsClient/GalaxyBudsClient.csproj
+    - name: Build Universal
+      run: dotnet publish -o bin_osx -c Release -p:TrimMode=full --no-restore GalaxyBudsClient/GalaxyBudsClient.csproj
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: GalaxyBudsClient_osx-universal
+        path: bin_osx/GalaxyBudsClient-*.pkg
+
   build-x64:
     runs-on: macos-14
 
@@ -33,7 +70,7 @@ jobs:
         project: ThePBone.OSX.Native/Native/NativeInterop.xcodeproj
         scheme: NativeInterop
         destination: platform=macOS,arch=x86_64
-        build-settings: CONFIGURATION_BUILD_DIR=/Users/runner/work/GalaxyBudsClient/GalaxyBudsClient/ThePBone.OSX.Native/Native/Build/Release CONFIGURATION_TEMP_DIR=/Users/runner/work/GalaxyBudsClient/GalaxyBudsClient/ThePBone.OSX.Native/Native/Build/Intermediates.noindex
+        build-settings: ARCHS=x86_64 ONLY_ACTIVE_ARCH=NO CONFIGURATION_BUILD_DIR=/Users/runner/work/GalaxyBudsClient/GalaxyBudsClient/ThePBone.OSX.Native/Native/Build/Release CONFIGURATION_TEMP_DIR=/Users/runner/work/GalaxyBudsClient/GalaxyBudsClient/ThePBone.OSX.Native/Native/Build/Intermediates.noindex
         action: build
        
     - name: Restore workloads
@@ -41,7 +78,7 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore -r osx-x64 --configfile GalaxyBudsClient/nuget.config GalaxyBudsClient/GalaxyBudsClient.csproj
     - name: Build x64
-      run: dotnet publish -r osx-x64 -o bin_osxx64 -c Release --no-restore GalaxyBudsClient/GalaxyBudsClient.csproj
+      run: dotnet publish -r osx-x64 -o bin_osxx64 -c Release -p:TrimMode=full --self-contained true --no-restore GalaxyBudsClient/GalaxyBudsClient.csproj
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
@@ -70,7 +107,7 @@ jobs:
         project: ThePBone.OSX.Native/Native/NativeInterop.xcodeproj
         scheme: NativeInterop
         destination: platform=macOS,arch=arm64
-        build-settings: CONFIGURATION_BUILD_DIR=/Users/runner/work/GalaxyBudsClient/GalaxyBudsClient/ThePBone.OSX.Native/Native/Build/Release CONFIGURATION_TEMP_DIR=/Users/runner/work/GalaxyBudsClient/GalaxyBudsClient/ThePBone.OSX.Native/Native/Build/Intermediates.noindex
+        build-settings: ARCHS=arm64 ONLY_ACTIVE_ARCH=NO CONFIGURATION_BUILD_DIR=/Users/runner/work/GalaxyBudsClient/GalaxyBudsClient/ThePBone.OSX.Native/Native/Build/Release CONFIGURATION_TEMP_DIR=/Users/runner/work/GalaxyBudsClient/GalaxyBudsClient/ThePBone.OSX.Native/Native/Build/Intermediates.noindex
         action: build
 
     - name: Restore workloads
@@ -78,7 +115,7 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore -r osx-arm64 --configfile GalaxyBudsClient/nuget.config GalaxyBudsClient/GalaxyBudsClient.csproj
     - name: Build arm64
-      run: dotnet publish -r osx-arm64 -o bin_osxarm64 -c Release --no-restore GalaxyBudsClient/GalaxyBudsClient.csproj
+      run: dotnet publish -r osx-arm64 -o bin_osxarm64 -c Release -p:TrimMode=full --self-contained true --no-restore GalaxyBudsClient/GalaxyBudsClient.csproj
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
@@ -89,10 +126,18 @@ jobs:
 
   attach-to-release:
     runs-on: ubuntu-latest
-    needs: [build-x64, build-arm64]
+    needs: [build-universal, build-x64, build-arm64]
     if: github.event_name == 'release'
      
     steps:
+    - name: Download setup artifact (Universal)
+      uses: actions/download-artifact@v3
+      with:
+        name: GalaxyBudsClient_osx-universal
+
+    - name: Rename (Universal)
+      run: mv GalaxyBudsClient-*.pkg GalaxyBudsClient_macOS_universal.pkg
+
     - name: Download setup artifact (x64)
       uses: actions/download-artifact@v3
       with:

--- a/GalaxyBudsClient/App.xaml.cs
+++ b/GalaxyBudsClient/App.xaml.cs
@@ -1,4 +1,8 @@
 using System;
+#if OSX
+using AppKit;
+using Avalonia.Threading;
+#endif
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
@@ -23,6 +27,17 @@ namespace GalaxyBudsClient
         {
             DataContext = this;
             
+#if OSX
+            NSApplication.Init();
+            NSApplication.Notifications.ObserveDidBecomeActive((_, _) =>
+            {
+                Dispatcher.UIThread.InvokeAsync(delegate
+                {
+                    MainWindow.Instance.BringToFront();
+                });
+            });
+#endif
+
             AvaloniaXamlLoader.Load(this);
             
             if (Loc.IsTranslatorModeEnabled())

--- a/GalaxyBudsClient/App.xaml.cs
+++ b/GalaxyBudsClient/App.xaml.cs
@@ -51,7 +51,7 @@ namespace GalaxyBudsClient
             if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
             {
                 desktop.MainWindow = MainWindow.Instance;
-                desktop.Exit += (sender, args) =>
+                desktop.Exit += (_, _) =>
                 {
                     SettingsProvider.Instance.FirstLaunch = false;
                 };

--- a/GalaxyBudsClient/GalaxyBudsClient.csproj
+++ b/GalaxyBudsClient/GalaxyBudsClient.csproj
@@ -85,15 +85,20 @@
         <None Remove="bin\**" />
     </ItemGroup>
 
+    <PropertyGroup>
+        <!-- https://github.com/AvaloniaUI/Avalonia/commit/76caeedfd2baf1911f889011189d1c21657d2987,
+            last release at time of writing is 11.0.9, so anything newer should include a fix -->
+        <AvaloniaVersion>11.1.999-cibuild0044753-beta</AvaloniaVersion>
+    </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.0.7" />
-        <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.0.7" />
-        <PackageReference Include="Avalonia.Desktop" Version="11.0.7" />
-        <PackageReference Include="Avalonia.Diagnostics" Version="11.0.7" />
-        <PackageReference Include="Avalonia.Fonts.Inter" Version="11.0.7" />
-        <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="11.0.7" />
+        <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)" />
+        <PackageReference Include="Avalonia.Controls.DataGrid" Version="$(AvaloniaVersion)" />
+        <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
+        <PackageReference Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />
+        <PackageReference Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)" />
+        <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="$(AvaloniaVersion)" />
         <PackageReference Include="Avalonia.Svg.Skia" Version="11.0.0.13" />
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.7" />
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
         <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.0.6" />
         <PackageReference Include="Config.Net" Version="5.1.5" />
         <PackageReference Include="CS-Script.Core" Version="2.0.0" />

--- a/GalaxyBudsClient/MainWindow.xaml.cs
+++ b/GalaxyBudsClient/MainWindow.xaml.cs
@@ -248,9 +248,12 @@ namespace GalaxyBudsClient
 
         protected override void OnOpened(EventArgs e)
         {
-            HotkeyReceiverImpl.Reset();
-            HotkeyReceiverImpl.Instance.Update(silent: true);
-            
+            if (_firstShow)
+            {
+                HotkeyReceiverImpl.Reset();
+                HotkeyReceiverImpl.Instance.Update(silent: true);
+            }
+
             if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
             {
                 if (desktop.Args.Contains("/StartMinimized") && PlatformUtils.SupportsTrayIcon && _firstShow)

--- a/GalaxyBudsClient/Program.cs
+++ b/GalaxyBudsClient/Program.cs
@@ -140,6 +140,11 @@ namespace GalaxyBudsClient
         // Avalonia configuration, don't remove; also used by visual designer.
         public static AppBuilder BuildAvaloniaApp()
             => AppBuilder.Configure<App>()
+                .With(new MacOSPlatformOptions
+                {
+                    // https://github.com/AvaloniaUI/Avalonia/issues/14577
+                    DisableSetProcessName = true
+                })
                 .UsePlatformDetect()
                 .LogToTrace();
 

--- a/GalaxyBudsClient/nuget.config
+++ b/GalaxyBudsClient/nuget.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="AvaloniaCI" value="https://www.myget.org/F/avalonia-ci/api/v2" />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+    <add key="avalonia-nightly" value="https://nuget-feed-nightly.avaloniaui.net/v3/index.json" protocolVersion="3" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
I split up the tracker issue into two seperate issues linking to the Avalonia bug reports, because I can't do anything about those.
But those bugs aren't deal-breakers, and that's why I'm happy to announce the macOS port of GalaxyBudsClient is stable now. :D