### PR TITLE
CI: remove TrimMode=Full

### DIFF
--- a/.github/workflows/compile-macos.yml
+++ b/.github/workflows/compile-macos.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore --configfile GalaxyBudsClient/nuget.config GalaxyBudsClient/GalaxyBudsClient.csproj
     - name: Build Universal
-      run: dotnet publish -o bin_osx -c Release -p:TrimMode=full --no-restore GalaxyBudsClient/GalaxyBudsClient.csproj
+      run: dotnet publish -o bin_osx -c Release --no-restore GalaxyBudsClient/GalaxyBudsClient.csproj
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
@@ -78,7 +78,7 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore -r osx-x64 --configfile GalaxyBudsClient/nuget.config GalaxyBudsClient/GalaxyBudsClient.csproj
     - name: Build x64
-      run: dotnet publish -r osx-x64 -o bin_osxx64 -c Release -p:TrimMode=full --self-contained true --no-restore GalaxyBudsClient/GalaxyBudsClient.csproj
+      run: dotnet publish -r osx-x64 -o bin_osxx64 -c Release --self-contained true --no-restore GalaxyBudsClient/GalaxyBudsClient.csproj
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
@@ -115,7 +115,7 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore -r osx-arm64 --configfile GalaxyBudsClient/nuget.config GalaxyBudsClient/GalaxyBudsClient.csproj
     - name: Build arm64
-      run: dotnet publish -r osx-arm64 -o bin_osxarm64 -c Release -p:TrimMode=full --self-contained true --no-restore GalaxyBudsClient/GalaxyBudsClient.csproj
+      run: dotnet publish -r osx-arm64 -o bin_osxarm64 -c Release --self-contained true --no-restore GalaxyBudsClient/GalaxyBudsClient.csproj
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
While this sacrifice hurts (doubled binary size), Config.NET/Castle.DynamicProxy breaks with TrimMode=Full