### PR TITLE
fixes for macOS

### DIFF
--- a/.github/workflows/compile-macos.yml
+++ b/.github/workflows/compile-macos.yml
@@ -47,7 +47,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: GalaxyBudsClient_osx-universal
-        path: bin_osx/GalaxyBudsClient-*.pkg
+        path: bin_osx/Galaxy Buds Manager-*.pkg
 
   build-x64:
     runs-on: macos-14
@@ -84,7 +84,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: GalaxyBudsClient_osx-x64
-        path: bin_osxx64/GalaxyBudsClient-*.pkg
+        path: bin_osxx64/Galaxy Buds Manager-*.pkg
 
   build-arm64:
     runs-on: macos-14
@@ -121,7 +121,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: GalaxyBudsClient_osx-arm64
-        path: bin_osxarm64/GalaxyBudsClient-*.pkg
+        path: bin_osxarm64/Galaxy Buds Manager-*.pkg
 
 
   attach-to-release:
@@ -136,7 +136,7 @@ jobs:
         name: GalaxyBudsClient_osx-universal
 
     - name: Rename (Universal)
-      run: mv GalaxyBudsClient-*.pkg GalaxyBudsClient_macOS_universal.pkg
+      run: mv "Galaxy Buds Manager"-*.pkg GalaxyBudsClient_macOS_universal.pkg
 
     - name: Download setup artifact (x64)
       uses: actions/download-artifact@v3
@@ -144,7 +144,7 @@ jobs:
         name: GalaxyBudsClient_osx-x64
     
     - name: Rename (x64)
-      run: mv GalaxyBudsClient-*.pkg GalaxyBudsClient_macOS_x64.pkg
+      run: mv "Galaxy Buds Manager"-*.pkg GalaxyBudsClient_macOS_x64.pkg
 
     - name: Download artifact (arm64)
       uses: actions/download-artifact@v3
@@ -152,7 +152,7 @@ jobs:
         name: GalaxyBudsClient_osx-arm64
 
     - name: Rename (arm64)
-      run: mv GalaxyBudsClient-*.pkg GalaxyBudsClient_macOS_arm64.pkg
+      run: mv "Galaxy Buds Manager"-*.pkg GalaxyBudsClient_macOS_arm64.pkg
 
     - uses: AButler/upload-release-assets@v2.0
       with:

--- a/GalaxyBudsClient/GalaxyBudsClient.csproj
+++ b/GalaxyBudsClient/GalaxyBudsClient.csproj
@@ -46,7 +46,8 @@
         <RuntimeIdentifiers>osx-x64;osx-arm64</RuntimeIdentifiers>
         <_XSAppIconAssets>Assets.xcassets/AppIcon.appiconset</_XSAppIconAssets>
         <ApplicationVersion>$(Version)</ApplicationVersion>
-	<SupportedOSPlatformVersion>12.0</SupportedOSPlatformVersion>
+        <AssemblyName>Galaxy Buds Manager</AssemblyName>
+	    <SupportedOSPlatformVersion>12.0</SupportedOSPlatformVersion>
     </PropertyGroup>
     <PropertyGroup Condition="'$(IsLinux)'=='true'">
         <DefineConstants>Linux</DefineConstants>

--- a/GalaxyBudsClient/Info.plist
+++ b/GalaxyBudsClient/Info.plist
@@ -3,6 +3,10 @@
 <plist version="1.0">
 <dict>
 	<key>NSBluetoothAlwaysUsageDescription</key>
-	<string>GalaxyBudsClient uses Bluetooth to access Galaxy Buds devices</string>
+	<string>Galaxy Buds Manager uses Bluetooth to access Galaxy Buds devices</string>
+	<key>CFBundleName</key>
+	<string>Galaxy Buds Manager</string>
+	<key>CFBundleDisplayName</key>
+	<string>Galaxy Buds Manager</string>
 </dict>
 </plist>

--- a/GalaxyBudsClient/Interface/Pages/AmbientSoundPage.xaml.cs
+++ b/GalaxyBudsClient/Interface/Pages/AmbientSoundPage.xaml.cs
@@ -64,6 +64,7 @@ namespace GalaxyBudsClient.Interface.Pages
                         await BluetoothImpl.Instance.SendRequestAsync(SPPMessage.MessageIds.SET_AMBIENT_MODE,
                             !_ambientSwitch.IsChecked);
                         _ambientSwitch.Toggle();
+                        EventDispatcher.Instance.Dispatch(EventDispatcher.Event.UpdateTrayIcon);
                         break;
                     case EventDispatcher.Event.AmbientVolumeUp:
                         _ambientSwitch.IsChecked = true;
@@ -76,6 +77,7 @@ namespace GalaxyBudsClient.Interface.Pages
                             true);
                         await BluetoothImpl.Instance.SendRequestAsync(SPPMessage.MessageIds.AMBIENT_VOLUME,
                             (byte) _volumeSlider.Value);
+                        EventDispatcher.Instance.Dispatch(EventDispatcher.Event.UpdateTrayIcon);
                         break;
                     case EventDispatcher.Event.AmbientVolumeDown:
                         if (_volumeSlider.Value <= 0)
@@ -94,6 +96,7 @@ namespace GalaxyBudsClient.Interface.Pages
                             await BluetoothImpl.Instance.SendRequestAsync(SPPMessage.MessageIds.AMBIENT_VOLUME,
                                 (byte) _volumeSlider.Value);
                         }
+                        EventDispatcher.Instance.Dispatch(EventDispatcher.Event.UpdateTrayIcon);
 
                         break;
                 }
@@ -148,6 +151,7 @@ namespace GalaxyBudsClient.Interface.Pages
         private async void AmbientToggle_OnToggled(object? sender, bool e)
         {
             await BluetoothImpl.Instance.SendRequestAsync(SPPMessage.MessageIds.SET_AMBIENT_MODE, e);
+            EventDispatcher.Instance.Dispatch(EventDispatcher.Event.UpdateTrayIcon);
         }
 
         private async void VoiceFocusToggle_OnToggled(object? sender, bool e)

--- a/GalaxyBudsClient/Interface/Pages/BixbyRemapPage.xaml.cs
+++ b/GalaxyBudsClient/Interface/Pages/BixbyRemapPage.xaml.cs
@@ -58,6 +58,7 @@ namespace GalaxyBudsClient.Interface.Pages
 			var items_act = new Dictionary<string, EventHandler<RoutedEventArgs>?>{};
 			foreach (var id in ((EventDispatcher.Event[]) Enum.GetValues(typeof(EventDispatcher.Event))))
 			{
+				if (!EventDispatcher.CheckDeviceSupport(id)) continue;
 				items_act.Add(id.GetDescription(), (sender, args) =>
 				{
 					if (id == EventDispatcher.Event.Connect)

--- a/GalaxyBudsClient/Interface/Pages/HomePage.xaml.cs
+++ b/GalaxyBudsClient/Interface/Pages/HomePage.xaml.cs
@@ -165,7 +165,9 @@ namespace GalaxyBudsClient.Interface.Pages
 
         private async void OnEventReceived(EventDispatcher.Event e, object? arg)
         {
-            if (!BluetoothImpl.Instance.DeviceSpec.Supports(IDeviceSpec.Feature.Anc))
+            // NoiseControl case is handled in NoiseProPage.xaml.cs
+            if (!BluetoothImpl.Instance.DeviceSpec.Supports(IDeviceSpec.Feature.Anc)
+                || BluetoothImpl.Instance.DeviceSpec.Supports(IDeviceSpec.Feature.NoiseControl))
             {
                 return;
             }
@@ -175,6 +177,7 @@ namespace GalaxyBudsClient.Interface.Pages
                 case EventDispatcher.Event.AncToggle:
                     await BluetoothImpl.Instance.SendRequestAsync(SPPMessage.MessageIds.SET_NOISE_REDUCTION, !_ancSwitch.IsChecked);
                     Dispatcher.UIThread.Post(_ancSwitch.Toggle);
+                    EventDispatcher.Instance.Dispatch(EventDispatcher.Event.UpdateTrayIcon);
                     break;
             }
         }

--- a/GalaxyBudsClient/Interface/Pages/TouchpadPage.xaml.cs
+++ b/GalaxyBudsClient/Interface/Pages/TouchpadPage.xaml.cs
@@ -76,6 +76,7 @@ namespace GalaxyBudsClient.Interface.Pages
 				case EventDispatcher.Event.ToggleDoubleEdgeTouch:
 					_edgeTouch.Toggle();
 					await BluetoothImpl.Instance.SendRequestAsync(SPPMessage.MessageIds.OUTSIDE_DOUBLE_TAP, _edgeTouch.IsChecked);
+					EventDispatcher.Instance.Dispatch(EventDispatcher.Event.UpdateTrayIcon);
 					break;
 			}
 		}
@@ -280,6 +281,7 @@ namespace GalaxyBudsClient.Interface.Pages
 			{
 				await BluetoothImpl.Instance.SendRequestAsync(SPPMessage.MessageIds.LOCK_TOUCHPAD, _lock.IsChecked);
 			}
+			EventDispatcher.Instance.Dispatch(EventDispatcher.Event.UpdateTrayIcon);
 		}
 		
 		private void BackButton_OnPointerPressed(object? sender, PointerPressedEventArgs e)
@@ -295,6 +297,7 @@ namespace GalaxyBudsClient.Interface.Pages
 		private async void DoubleTapVolume_OnToggled(object? sender, bool e)
 		{
 			await BluetoothImpl.Instance.SendRequestAsync(SPPMessage.MessageIds.OUTSIDE_DOUBLE_TAP, e);
+			EventDispatcher.Instance.Dispatch(EventDispatcher.Event.UpdateTrayIcon);
 		}
 
 		private void Gestures_OnPointerPressed(object? sender, PointerPressedEventArgs e)

--- a/GalaxyBudsClient/MainWindow.xaml.cs
+++ b/GalaxyBudsClient/MainWindow.xaml.cs
@@ -90,6 +90,7 @@ namespace GalaxyBudsClient
             if (PlatformUtils.IsOSX)
             {
                 SystemDecorations = SystemDecorations.Full;
+                ExtendClientAreaToDecorationsHint = true;
             }
             
             Pager = this.FindControl<PageContainer>("Container");

--- a/GalaxyBudsClient/Message/MessageComposer.cs
+++ b/GalaxyBudsClient/Message/MessageComposer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using GalaxyBudsClient.Model;
 using GalaxyBudsClient.Model.Constants;
 using GalaxyBudsClient.Platform;
 
@@ -62,6 +63,7 @@ namespace GalaxyBudsClient.Message
                 payload[0] = !enable ? (byte) 0 : Convert.ToByte(preset + 1);
                 await BluetoothImpl.Instance.SendRequestAsync(SPPMessage.MessageIds.EQUALIZER, payload);
             }
+            EventDispatcher.Instance.Dispatch(EventDispatcher.Event.UpdateTrayIcon);
         }
         
 
@@ -96,12 +98,12 @@ namespace GalaxyBudsClient.Message
             }
         }
         
-        /* Buds Pro only */
         public static class NoiseControl
         {
             public static async Task SetMode(NoiseControlMode mode)
             {
                 await BluetoothImpl.Instance.SendRequestAsync(SPPMessage.MessageIds.NOISE_CONTROLS, (byte)mode);
+                EventDispatcher.Instance.Dispatch(EventDispatcher.Event.UpdateTrayIcon);
             }
 
             public static async Task SetTouchNoiseControls(bool anc, bool ambient, bool off)

--- a/GalaxyBudsClient/Model/EventDispatcher.cs
+++ b/GalaxyBudsClient/Model/EventDispatcher.cs
@@ -54,6 +54,7 @@ namespace GalaxyBudsClient.Model
             Connect,
             
             /* INTERNAL */
+            UpdateTrayIcon,
             SetNoiseControlState
         }
 
@@ -101,6 +102,7 @@ namespace GalaxyBudsClient.Model
                     return BluetoothImpl.Instance.DeviceSpec.Supports(IDeviceSpec.Feature.DetectConversations);
                 
                 /* INTERNAL */
+                case Event.UpdateTrayIcon:
                 case Event.SetNoiseControlState:
                     return false;
             }

--- a/GalaxyBudsClient/Utils/LocalizationUtils.cs
+++ b/GalaxyBudsClient/Utils/LocalizationUtils.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Reflection;
 using System.Text;
 using System.Xml;
 using Avalonia;
@@ -48,7 +49,6 @@ namespace GalaxyBudsClient.Utils
 
             public static void Load()
             {
-
                 string lang = SettingsProvider.Instance.Locale.ToString();
                 if (lang.EndsWith("_"))
                     lang = lang.TrimEnd('_');
@@ -63,8 +63,8 @@ namespace GalaxyBudsClient.Utils
                     lang = Locales.en.ToString();
                     SettingsProvider.Instance.Locale = Locales.en;
                 }
-
-                SetLanguageResourceDictionary($"avares://GalaxyBudsClient/i18n/{lang}.xaml", external: false);
+                var assemblyName = Assembly.GetEntryAssembly()?.GetName().Name;
+                SetLanguageResourceDictionary($"avares://{assemblyName}/i18n/{lang}.xaml", external: false);
             }
             
             private static void SetLanguageResourceDictionary(string path, bool external)

--- a/GalaxyBudsClient/Utils/ThemeUtils.cs
+++ b/GalaxyBudsClient/Utils/ThemeUtils.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Reflection;
 using System.Text;
 using Avalonia;
 using Avalonia.Controls;
@@ -56,10 +57,11 @@ namespace GalaxyBudsClient.Utils
                 }
                 else
                 {
+                    var assemblyName = Assembly.GetEntryAssembly()?.GetName().Name;
                     Application.Current.Resources.MergedDictionaries[dictId] =
                         new ResourceInclude((Uri?)null)
                         {
-                            Source = new Uri($"avares://GalaxyBudsClient/Interface/Styles/{name}.xaml")
+                            Source = new Uri($"avares://{assemblyName}/Interface/Styles/{name}.xaml")
                         };
                 }
             }


### PR DESCRIPTION
- Set app name to user friendly name
- Fix double title bar
- Fix tray icon crash by updating the tray icon only when needed and while it's closed