### PR TITLE
Better macOS window

### DIFF
--- a/GalaxyBudsClient/Interface/CustomTitleBar.xaml
+++ b/GalaxyBudsClient/Interface/CustomTitleBar.xaml
@@ -26,7 +26,7 @@
                             HorizontalAlignment="Left" BorderThickness="0">
                         <TextBlock Text="{DynamicResource optionsmenu_title}"
                                    FontSize="13"
-                                   Foreground=="{OnPlatform Default={DynamicResource ForegroundTextBrush}, macOS={DynamicResource SubtitleTextBrush}}"
+                                   Foreground="{OnPlatform Default={DynamicResource ForegroundTextBrush}, macOS={DynamicResource SubtitleTextBrush}}"
                                    HorizontalAlignment="Left"
                                    TextAlignment="Center"
                                    VerticalAlignment="Center">

--- a/GalaxyBudsClient/Interface/CustomTitleBar.xaml
+++ b/GalaxyBudsClient/Interface/CustomTitleBar.xaml
@@ -5,7 +5,7 @@
              xmlns:ui="clr-namespace:GalaxyBudsClient.Interface"
              mc:Ignorable="d" d:DesignWidth="500" d:DesignHeight="{OnPlatform '36', macOS='30'}"
              x:Class="GalaxyBudsClient.Interface.CustomTitleBar"
-             DockPanel.Dock="Top" Margin="10,0">
+             DockPanel.Dock="Top" Margin="{OnPlatform '10,0', macOS='0,0'}">
     <StackPanel>
         <Grid>
             <!--The proper way would be not to use white as default, but somehow retrieve the users' window chrome color.-->
@@ -22,8 +22,8 @@
                         <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
 
-                    <Button x:Name="OptionsButton" Grid.Column="0"
-                            HorizontalAlignment="Left" BorderThickness="0" Margin="{OnPlatform '0,0,0,0', macOS='50,0,0,0'}">
+                    <Button x:Name="OptionsButton" Grid.Column="{OnPlatform '0', macOS='2'}"
+                            HorizontalAlignment="Left" BorderThickness="0">
                         <TextBlock Text="{DynamicResource optionsmenu_title}"
                                    FontSize="13"
                                    Foreground="{DynamicResource ForegroundTextBrush}"
@@ -56,7 +56,7 @@
                                Padding="60 0 60 0"
                                Foreground="{DynamicResource ForegroundTextBrush}"/>
 
-                    <StackPanel x:Name="WindowControlsGrid" Grid.Column="2" Background="Transparent"
+                    <StackPanel x:Name="WindowControlsGrid" "{OnPlatform '2', macOS='0'}" Background="Transparent"
                                 Orientation="Horizontal">
                         <Button Width="{OnPlatform '26', macOS='0'}"
                                 Height="{OnPlatform '26', macOS='0'}"

--- a/GalaxyBudsClient/Interface/CustomTitleBar.xaml
+++ b/GalaxyBudsClient/Interface/CustomTitleBar.xaml
@@ -26,7 +26,7 @@
                             HorizontalAlignment="Left" BorderThickness="0">
                         <TextBlock Text="{DynamicResource optionsmenu_title}"
                                    FontSize="13"
-                                   Foreground="{DynamicResource ForegroundTextBrush}"
+                                   Foreground=="{OnPlatform Default={DynamicResource ForegroundTextBrush}, macOS={DynamicResource SubtitleTextBrush}}"
                                    HorizontalAlignment="Left"
                                    TextAlignment="Center"
                                    VerticalAlignment="Center">

--- a/GalaxyBudsClient/Interface/CustomTitleBar.xaml
+++ b/GalaxyBudsClient/Interface/CustomTitleBar.xaml
@@ -56,7 +56,7 @@
                                Padding="60 0 60 0"
                                Foreground="{DynamicResource ForegroundTextBrush}"/>
 
-                    <StackPanel x:Name="WindowControlsGrid" "{OnPlatform '2', macOS='0'}" Background="Transparent"
+                    <StackPanel x:Name="WindowControlsGrid" Grid.Column="{OnPlatform '2', macOS='0'}" Background="Transparent"
                                 Orientation="Horizontal">
                         <Button Width="{OnPlatform '26', macOS='0'}"
                                 Height="{OnPlatform '26', macOS='0'}"

--- a/GalaxyBudsClient/Interface/CustomTitleBar.xaml
+++ b/GalaxyBudsClient/Interface/CustomTitleBar.xaml
@@ -3,7 +3,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:ui="clr-namespace:GalaxyBudsClient.Interface"
-             mc:Ignorable="d" d:DesignWidth="500" d:DesignHeight="36"
+             mc:Ignorable="d" d:DesignWidth="500" d:DesignHeight="{OnPlatform '36', macOS='30'}"
              x:Class="GalaxyBudsClient.Interface.CustomTitleBar"
              DockPanel.Dock="Top" Margin="10,0">
     <StackPanel>
@@ -14,7 +14,7 @@
                        Name="TitleBarBackground" />
             <DockPanel Name="TitleBar">
 
-                <Grid x:Name="PART_HeaderBar" Height="36"
+                <Grid x:Name="PART_HeaderBar" Height="{OnPlatform '36', macOS='30'}"
                       Background="{DynamicResource WindowHeaderBrush}">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" />
@@ -23,7 +23,7 @@
                     </Grid.ColumnDefinitions>
 
                     <Button x:Name="OptionsButton" Grid.Column="0"
-                            HorizontalAlignment="Left" BorderThickness="0">
+                            HorizontalAlignment="Left" BorderThickness="0" Margin="{OnPlatform '0,0,0,0', macOS='50,0,0,0'}">
                         <TextBlock Text="{DynamicResource optionsmenu_title}"
                                    FontSize="13"
                                    Foreground="{DynamicResource ForegroundTextBrush}"
@@ -58,8 +58,8 @@
 
                     <StackPanel x:Name="WindowControlsGrid" Grid.Column="2" Background="Transparent"
                                 Orientation="Horizontal">
-                        <Button Width="26"
-                                Height="26"
+                        <Button Width="{OnPlatform '26', macOS='0'}"
+                                Height="{OnPlatform '26', macOS='0'}"
                                 HorizontalContentAlignment="Center"
                                 BorderThickness="0"
                                 Name="MinimizeButton"
@@ -83,7 +83,8 @@
                                   Data="M2048 1229v-205h-2048v205h2048z" />
                         </Button>
 
-                        <Button Width="26" Height="26"
+                        <Button Width="{OnPlatform '26', macOS='0'}"
+                                Height="{OnPlatform '26', macOS='0'}"
                                 VerticalAlignment="Stretch"
                                 BorderThickness="0"
                                 Name="CloseButton"

--- a/GalaxyBudsClient/MainWindow.xaml
+++ b/GalaxyBudsClient/MainWindow.xaml
@@ -11,7 +11,7 @@
         MinHeight="640" MinWidth="700"
         CanResize="False"
         WindowStartupLocation="CenterScreen"
-        ExtendClientAreaChromeHints="NoChrome"
+        ExtendClientAreaChromeHints="{OnPlatform 'NoChrome', macOS='SystemChrome'}"
         ExtendClientAreaTitleBarHeightHint="-1"
         TransparencyLevelHint="Transparent"
         SystemDecorations="None"
@@ -20,7 +20,7 @@
         Icon="/Resources/icon_white.ico"
         Title="Galaxy Buds Manager">
     
-    <Border CornerRadius="{StaticResource DefaultCornerRadius}"
+    <Border CornerRadius="{OnPlatform Default={StaticResource DefaultCornerRadius}, macOS='10'}"
             BorderBrush="{DynamicResource WindowBorderBrush}"
             BorderThickness="1" Padding="1"
             Background="{DynamicResource WindowBackgroundBrush}">

--- a/GalaxyBudsClient/MainWindow.xaml
+++ b/GalaxyBudsClient/MainWindow.xaml
@@ -20,7 +20,7 @@
         Icon="/Resources/icon_white.ico"
         Title="Galaxy Buds Manager">
     
-    <Border CornerRadius="{OnPlatform Default={StaticResource DefaultCornerRadius}, macOS='10'}"
+    <Border CornerRadius="{OnPlatform Default={StaticResource DefaultCornerRadius}, macOS=10}"
             BorderBrush="{DynamicResource WindowBorderBrush}"
             BorderThickness="1" Padding="1"
             Background="{DynamicResource WindowBackgroundBrush}">

--- a/GalaxyBudsClient/MainWindow.xaml
+++ b/GalaxyBudsClient/MainWindow.xaml
@@ -20,7 +20,7 @@
         Icon="/Resources/icon_white.ico"
         Title="Galaxy Buds Manager">
     
-    <Border CornerRadius="{OnPlatform '20', macOS='10'}"
+    <Border CornerRadius="{OnPlatform '20', macOS='9'}"
             BorderBrush="{DynamicResource WindowBorderBrush}"
             BorderThickness="1" Padding="1"
             Background="{DynamicResource WindowBackgroundBrush}">

--- a/GalaxyBudsClient/MainWindow.xaml
+++ b/GalaxyBudsClient/MainWindow.xaml
@@ -20,7 +20,7 @@
         Icon="/Resources/icon_white.ico"
         Title="Galaxy Buds Manager">
     
-    <Border CornerRadius="{OnPlatform Default={StaticResource DefaultCornerRadius}, macOS=10}"
+    <Border CornerRadius="{OnPlatform '20', macOS='10'}"
             BorderBrush="{DynamicResource WindowBorderBrush}"
             BorderThickness="1" Padding="1"
             Background="{DynamicResource WindowBackgroundBrush}">


### PR DESCRIPTION
<img width="750" alt="Screenshot 2024-03-03 at 11 12 36 AM" src="https://github.com/ThePBone/GalaxyBudsClient/assets/17254413/5b500aba-b57b-4856-9dc4-e606e8289677">

In MainWindow.xaml I had to hardcode the `CornerRadius` to 20 instead of getting it from the `DefaultCornerRadius` value because `<Border CornerRadius="{OnPlatform Default={StaticResource DefaultCornerRadius}, macOS='10'}"` would cause the app to not open for some reason.